### PR TITLE
refactor: rename Spot* to Riff* across app, settings, dbus, oauth, cache

### DIFF
--- a/src/app/components/settings/settings.rs
+++ b/src/app/components/settings/settings.rs
@@ -1,6 +1,6 @@
 use crate::app::components::EventListener;
 use crate::app::AppEvent;
-use crate::settings::SpotSettings;
+use crate::settings::RiffSettings;
 
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
@@ -256,7 +256,7 @@ impl Settings {
         let settings_dialog = SettingsDialog::new();
 
         settings_dialog.connect_close(move || {
-            let new_settings = SpotSettings::new_from_gsettings().unwrap_or_default();
+            let new_settings = RiffSettings::new_from_gsettings().unwrap_or_default();
             if model.settings().player_settings != new_settings.player_settings {
                 model.stop_player();
             }

--- a/src/app/components/settings/settings_model.rs
+++ b/src/app/components/settings/settings_model.rs
@@ -1,6 +1,6 @@
 use crate::app::state::{PlaybackAction, SettingsAction};
 use crate::app::{ActionDispatcher, AppModel};
-use crate::settings::SpotSettings;
+use crate::settings::RiffSettings;
 use std::rc::Rc;
 
 pub struct SettingsModel {
@@ -25,7 +25,7 @@ impl SettingsModel {
             .dispatch(SettingsAction::ChangeSettings.into());
     }
 
-    pub fn settings(&self) -> SpotSettings {
+    pub fn settings(&self) -> RiffSettings {
         let state = self.app_model.get_state();
         state.settings.settings.clone()
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,6 @@
-use crate::settings::SpotSettings;
-use crate::{api::CachedSpotifyClient, player::TokenStore};
+use crate::settings::RiffSettings;
 use crate::PlaybackAction;
+use crate::{api::CachedSpotifyClient, player::TokenStore};
 use futures::channel::mpsc::UnboundedSender;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -30,7 +30,7 @@ pub use rng::LazyRandomIndex;
 
 // Where all the app logic happens
 pub struct App {
-    settings: SpotSettings,
+    settings: RiffSettings,
     // The builder instance used to properly configure all the widgets created at startup
     builder: gtk::Builder,
     // All the "components" that will be notified of things happening throughout the app
@@ -44,7 +44,7 @@ pub struct App {
 
 impl App {
     pub fn new(
-        settings: SpotSettings,
+        settings: RiffSettings,
         builder: gtk::Builder,
         sender: UnboundedSender<AppAction>,
         worker: Worker,
@@ -121,7 +121,7 @@ impl App {
     // A component that listens to what's happening in the app, and translates it for the actual player
     fn make_player_notifier(
         app_model: Rc<AppModel>,
-        settings: &SpotSettings,
+        settings: &RiffSettings,
         dispatcher: Box<dyn ActionDispatcher>,
         sender: UnboundedSender<AppAction>,
         token_store: Arc<TokenStore>,
@@ -150,7 +150,7 @@ impl App {
     }
 
     fn make_window(
-        settings: &SpotSettings,
+        settings: &RiffSettings,
         builder: &gtk::Builder,
         app_model: Rc<AppModel>,
     ) -> Box<impl EventListener> {

--- a/src/app/state/settings_state.rs
+++ b/src/app/state/settings_state.rs
@@ -1,6 +1,6 @@
 use crate::{
     app::state::{AppAction, AppEvent, UpdatableState},
-    settings::SpotSettings,
+    settings::RiffSettings,
 };
 
 #[derive(Clone, Debug)]
@@ -28,7 +28,7 @@ impl From<SettingsEvent> for AppEvent {
 #[derive(Default)]
 pub struct SettingsState {
     // Probably shouldn't be stored, the source of truth is GSettings anyway
-    pub settings: SpotSettings,
+    pub settings: RiffSettings,
 }
 
 impl UpdatableState for SettingsState {
@@ -39,7 +39,7 @@ impl UpdatableState for SettingsState {
         match action.into_owned() {
             SettingsAction::ChangeSettings => {
                 let old_settings = &self.settings;
-                let new_settings = SpotSettings::new_from_gsettings().unwrap_or_default();
+                let new_settings = RiffSettings::new_from_gsettings().unwrap_or_default();
                 let player_settings_changed =
                     new_settings.player_settings != old_settings.player_settings;
                 self.settings = new_settings;

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -16,8 +16,8 @@ use listener::*;
 
 #[tokio::main]
 async fn dbus_server(
-    mpris: SpotMpris,
-    player: SpotMprisPlayer,
+    mpris: RiffMpris,
+    player: RiffMprisPlayer,
     receiver: UnboundedReceiver<MprisStateUpdate>,
 ) -> zbus::Result<()> {
     let connection = Connection::session().await?;
@@ -37,7 +37,7 @@ async fn dbus_server(
         .for_each(|update| async {
             if let Ok(player_ref) = connection
                 .object_server()
-                .interface::<_, SpotMprisPlayer>("/org/mpris/MediaPlayer2")
+                .interface::<_, RiffMprisPlayer>("/org/mpris/MediaPlayer2")
                 .await
             {
                 let mut player = player_ref.get_mut().await;
@@ -92,8 +92,8 @@ pub fn start_dbus_server(
     app_model: Rc<AppModel>,
     sender: UnboundedSender<AppAction>,
 ) -> AppPlaybackStateListener {
-    let mpris = SpotMpris::new(sender.clone());
-    let player = SpotMprisPlayer::new(sender);
+    let mpris = RiffMpris::new(sender.clone());
+    let player = RiffMprisPlayer::new(sender);
 
     let (sender, receiver) = unbounded();
 

--- a/src/dbus/mpris.rs
+++ b/src/dbus/mpris.rs
@@ -15,18 +15,18 @@ use crate::app::state::PlaybackAction;
 use crate::app::AppAction;
 
 #[derive(Clone)]
-pub struct SpotMpris {
+pub struct RiffMpris {
     sender: UnboundedSender<AppAction>,
 }
 
-impl SpotMpris {
+impl RiffMpris {
     pub fn new(sender: UnboundedSender<AppAction>) -> Self {
         Self { sender }
     }
 }
 
 #[interface(interface = "org.mpris.MediaPlayer2")]
-impl SpotMpris {
+impl RiffMpris {
     fn quit(&self) -> Result<()> {
         Err(Error::NotSupported("Not implemented".to_string()))
     }
@@ -73,12 +73,12 @@ impl SpotMpris {
     }
 }
 
-pub struct SpotMprisPlayer {
+pub struct RiffMprisPlayer {
     state: MprisState,
     sender: UnboundedSender<AppAction>,
 }
 
-impl SpotMprisPlayer {
+impl RiffMprisPlayer {
     pub fn new(sender: UnboundedSender<AppAction>) -> Self {
         Self {
             state: MprisState::new(),
@@ -128,7 +128,7 @@ impl SpotMprisPlayer {
 }
 
 #[interface(interface = "org.mpris.MediaPlayer2.Player")]
-impl SpotMprisPlayer {
+impl RiffMprisPlayer {
     pub fn next(&self) -> Result<()> {
         self.sender
             .unbounded_send(PlaybackAction::Next.into())

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use crate::app::dispatch::{spawn_task_handler, DispatchLoop};
 use crate::app::{state::PlaybackAction, App, AppAction, BrowserAction};
 
 fn main() {
-    let settings = settings::SpotSettings::new_from_gsettings().unwrap_or_default();
+    let settings = settings::RiffSettings::new_from_gsettings().unwrap_or_default();
     setup_gtk(&settings);
 
     // Looks like there's a side effect to declaring widgets that allows them to be referenced them in ui/blueprint files
@@ -93,7 +93,7 @@ fn main() {
     std::process::exit(0);
 }
 
-fn setup_gtk(settings: &settings::SpotSettings) {
+fn setup_gtk(settings: &settings::RiffSettings) {
     // Setup logging
     env_logger::init();
 

--- a/src/player/oauth2.rs
+++ b/src/player/oauth2.rs
@@ -47,7 +47,7 @@ user-modify-playback-state,\
 streaming,\
 playlist-modify-public";
 
-pub struct SpotOauthClient {
+pub struct RiffOauthClient {
     client: BasicClient,
     token_store: Arc<TokenStore>,
 }
@@ -58,7 +58,7 @@ pub struct AuthcodeChallenge {
     listener: JoinHandle<Result<AuthorizationCode, OAuthError>>,
 }
 
-impl SpotOauthClient {
+impl RiffOauthClient {
     pub fn new(token_store: Arc<TokenStore>) -> Self {
         let auth_url = AuthUrl::new("https://accounts.spotify.com/authorize".to_string())
             .expect("Malformed URL");

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -14,11 +14,11 @@ use librespot::playback::config::{AudioFormat, Bitrate, PlayerConfig, VolumeCtrl
 use librespot::playback::player::{Player, PlayerEvent, PlayerEventChannel};
 use url::Url;
 
-use super::oauth2::{AuthcodeChallenge, SpotOauthClient};
+use super::oauth2::{AuthcodeChallenge, RiffOauthClient};
 use super::{Command, TokenStore};
 use crate::app::credentials;
 use crate::player::oauth2::OAuthError;
-use crate::settings::SpotSettings;
+use crate::settings::RiffSettings;
 use std::env;
 use std::error::Error;
 use std::fmt;
@@ -91,7 +91,7 @@ pub struct SpotifyPlayer {
     session: Option<Session>,
 
     // Auth related stuff
-    oauth_client: Arc<SpotOauthClient>,
+    oauth_client: Arc<RiffOauthClient>,
     auth_challenge: Option<AuthcodeChallenge>,
     command_sender: UnboundedSender<Command>,
 
@@ -111,7 +111,7 @@ impl SpotifyPlayer {
             mixer: None,
             player: None,
             session: None,
-            oauth_client: Arc::new(SpotOauthClient::new(token_store)),
+            oauth_client: Arc::new(RiffOauthClient::new(token_store)),
             auth_challenge: None,
             command_sender,
             delegate,
@@ -236,7 +236,7 @@ impl SpotifyPlayer {
                 self.initial_login(credentials).await
             }
             Command::ReloadSettings => {
-                let settings = SpotSettings::new_from_gsettings().unwrap_or_default();
+                let settings = RiffSettings::new_from_gsettings().unwrap_or_default();
                 self.settings = settings.player_settings;
 
                 let session = self.session.take().ok_or(SpotifyError::PlayerNotReady)?;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -80,14 +80,14 @@ impl SpotifyPlayerSettings {
 }
 
 #[derive(Debug, Clone)]
-pub struct SpotSettings {
+pub struct RiffSettings {
     pub theme_preference: ColorScheme,
     pub player_settings: SpotifyPlayerSettings,
     pub window: WindowGeometry,
 }
 
 // Application settings
-impl SpotSettings {
+impl RiffSettings {
     pub fn new_from_gsettings() -> Option<Self> {
         let settings = gio::Settings::new(SETTINGS);
         let theme_preference = match settings.enum_("theme-preference") {
@@ -104,7 +104,7 @@ impl SpotSettings {
     }
 }
 
-impl Default for SpotSettings {
+impl Default for RiffSettings {
     fn default() -> Self {
         Self {
             theme_preference: ColorScheme::PreferDark,


### PR DESCRIPTION
## Summary

This PR completes the first pass of the project rebrand by renaming `Spot*` identifiers to `Riff*` throughout the codebase. Changes are mechanical with no intended behavior differences.

## What changed

- **`src/api/cached_client.rs`**: `SpotCacheKey` → `RiffCacheKey` and all call sites updated.
- **`src/settings.rs`**: `SpotSettings` → `RiffSettings` (constructors/default updated).
- **`src/app/...`**: App struct, window helpers, and model now use `RiffSettings`.
- **`src/app/components/settings/...`**: Settings UI reads/writes `RiffSettings`.
- **`src/app/state/settings_state.rs`**: State stores and reloads `RiffSettings`.
- **`src/dbus/mod.rs`, `src/dbus/mpris.rs`**: `SpotMpris`/`SpotMprisPlayer` → `RiffMpris`/`RiffMprisPlayer`.
- **`src/player/oauth2.rs`**: `SpotOauthClient` → `RiffOauthClient`.
- **`src/player/player.rs`**: Imports/fields updated to `RiffOauthClient` and `RiffSettings`.
- **`src/main.rs`**: Bootstraps with `settings::RiffSettings`.

# Rationale

- Aligns code with the new project name (“Riff”) and reduces confusion with the unmaintained upstream (“Spot”).

## Testing

- `cargo test` succeeds after the rename.
- Smoke tests:
  - App launches and settings dialog opens.
  - Player initializes; OAuth code paths compile with new client type.
  - Verified the MPRIS interface still exports under `org.mpris.MediaPlayer2`