### PR TITLE
Fix album art no longer scaling up

### DIFF
--- a/src/app/components/album/album.blp
+++ b/src/app/components/album/album.blp
@@ -15,8 +15,8 @@ template $AlbumWidget : Adw.Bin {
       orientation: vertical;
       spacing: 6;
 
-      Image cover_image {
-        icon-name: "media-playback-start-symbolic";
+      Picture cover_image {
+        content-fit: cover;
 
         styles [
           "card",

--- a/src/app/components/album/album.rs
+++ b/src/app/components/album/album.rs
@@ -28,7 +28,7 @@ mod imp {
         pub cover_btn: TemplateChild<gtk::Button>,
 
         #[template_child]
-        pub cover_image: TemplateChild<gtk::Image>,
+        pub cover_image: TemplateChild<gtk::Picture>,
     }
 
     #[glib::object_subclass]

--- a/src/app/components/details/album_header.blp
+++ b/src/app/components/details/album_header.blp
@@ -14,10 +14,10 @@ template $AlbumHeaderWidget : Box {
     margin-bottom: 6;
     margin-start: 6;
 
-    Image album_art {
+    Picture album_art {
       width-request: 160;
       height-request: 160;
-      icon-name: "emblem-music-symbolic";
+      content-fit: cover;
     }
 
     [overlay]

--- a/src/app/components/details/album_header.rs
+++ b/src/app/components/details/album_header.rs
@@ -21,7 +21,7 @@ mod imp {
         pub album_label: TemplateChild<gtk::Label>,
 
         #[template_child]
-        pub album_art: TemplateChild<gtk::Image>,
+        pub album_art: TemplateChild<gtk::Picture>,
 
         #[template_child]
         pub button_box: TemplateChild<gtk::Box>,

--- a/src/app/components/playback/playback_info.blp
+++ b/src/app/components/playback/playback_info.blp
@@ -15,10 +15,10 @@ template $PlaybackInfoWidget : Button {
   Box {
     halign: center;
 
-    Image playing_image {
+    Picture playing_image {
       width-request: 50;
       height-request: 50;
-      icon-name: "emblem-music-symbolic";
+      content-fit: cover;
     }
 
     Label current_song_info {

--- a/src/app/components/playback/playback_info.rs
+++ b/src/app/components/playback/playback_info.rs
@@ -11,7 +11,7 @@ mod imp {
     #[template(resource = "/dev/diegovsky/Riff/components/playback_info.ui")]
     pub struct PlaybackInfoWidget {
         #[template_child]
-        pub playing_image: TemplateChild<gtk::Image>,
+        pub playing_image: TemplateChild<gtk::Picture>,
 
         #[template_child]
         pub current_song_info: TemplateChild<gtk::Label>,
@@ -58,10 +58,7 @@ impl PlaybackInfoWidget {
             .set_label(&gettext("No song playing"));
         widget
             .playing_image
-            .set_icon_name(Some("emblem-music-symbolic"));
-        widget
-            .playing_image
-            .set_icon_name(Some("emblem-music-symbolic"));
+            .set_paintable(None::<gdk::Paintable>.as_ref());
     }
 
     pub fn set_info_visible(&self, visible: bool) {

--- a/src/app/components/playlist_details/playlist_header.blp
+++ b/src/app/components/playlist_details/playlist_header.blp
@@ -14,10 +14,10 @@ template $PlaylistHeaderWidget : Box {
     margin-start: 6;
     margin-bottom: 6;
 
-    Image playlist_art {
+    Picture playlist_art {
       width-request: 160;
       height-request: 160;
-      icon-name: "emblem-music-symbolic";
+      content-fit: cover;
     }
 
     styles [

--- a/src/app/components/playlist_details/playlist_header.rs
+++ b/src/app/components/playlist_details/playlist_header.rs
@@ -24,7 +24,7 @@ mod imp {
         pub playlist_image_box: TemplateChild<gtk::Box>,
 
         #[template_child]
-        pub playlist_art: TemplateChild<gtk::Image>,
+        pub playlist_art: TemplateChild<gtk::Picture>,
 
         #[template_child]
         pub playlist_info: TemplateChild<gtk::Box>,


### PR DESCRIPTION
by switching from GTK's `Image` to `Picture`.

Closes #31.