### PR TITLE
flatpak: fix pipewire backend

### DIFF
--- a/dev.diegovsky.Riff.snapshots.json
+++ b/dev.diegovsky.Riff.snapshots.json
@@ -11,6 +11,7 @@
 		"--socket=fallback-x11",
 		"--socket=wayland",
 		"--socket=pulseaudio",
+		"--filesystem=xdg-run/pipewire-0:ro",
 		"--device=dri",
 		"--talk-name=org.freedesktop.secrets",
 		"--own-name=org.mpris.MediaPlayer2.Riff"


### PR DESCRIPTION
Fixes #52

This approach is detailed at:
https://github.com/flatpak/flatpak/issues/5130
and
https://github.com/flathub/com.github.iwalton3.jellyfin-mpv-shim/pull/10/changes
