### PR TITLE
Fix long playlist headers

### DIFF
--- a/src/app/components/playlist_details/playlist_details.rs
+++ b/src/app/components/playlist_details/playlist_details.rs
@@ -51,12 +51,7 @@ mod imp {
         }
     }
 
-    impl ObjectImpl for PlaylistDetailsWidget {
-        fn constructed(&self) {
-            self.parent_constructed();
-            self.header_widget.set_grows_automatically();
-        }
-    }
+    impl ObjectImpl for PlaylistDetailsWidget {}
 
     impl WidgetImpl for PlaylistDetailsWidget {}
     impl BinImpl for PlaylistDetailsWidget {}

--- a/src/app/components/playlist_details/playlist_header.blp
+++ b/src/app/components/playlist_details/playlist_header.blp
@@ -1,6 +1,6 @@
 using Gtk 4.0;
 
-template $PlaylistHeaderWidget : Box {
+template $PlaylistHeaderWidget: Box {
   valign: start;
   vexpand: false;
   margin-start: 6;
@@ -27,14 +27,17 @@ template $PlaylistHeaderWidget : Box {
 
   Box playlist_info {
     hexpand: true;
+    hexpand-set: true;
     valign: center;
+    halign: fill;
     orientation: vertical;
     spacing: 6;
     margin-start: 18;
 
     Entry playlist_label_entry {
-      hexpand: false;
-      halign: start;
+      hexpand: true;
+      hexpand-set: true;
+      halign: fill;
       editable: false;
       can-focus: false;
       placeholder-text: "Playlist Title";
@@ -64,6 +67,7 @@ template $PlaylistHeaderWidget : Box {
       ]
     }
   }
+
   Button play_button {
     margin-end: 6;
     receives-default: true;

--- a/src/app/components/playlist_details/playlist_header.rs
+++ b/src/app/components/playlist_details/playlist_header.rs
@@ -52,13 +52,11 @@ mod imp {
             if vertical {
                 box_.set_orientation(gtk::Orientation::Vertical);
                 box_.set_spacing(12);
-                self.playlist_info.set_halign(gtk::Align::Center);
                 EntryExt::set_alignment(&*self.playlist_label_entry, 0.5);
                 self.author_button.set_halign(gtk::Align::Center);
             } else {
                 box_.set_orientation(gtk::Orientation::Horizontal);
                 box_.set_spacing(0);
-                self.playlist_info.set_halign(gtk::Align::Start);
                 EntryExt::set_alignment(&*self.playlist_label_entry, 0.0);
                 self.author_button.set_halign(gtk::Align::Start);
             }
@@ -175,14 +173,5 @@ impl PlaylistHeaderWidget {
 
     pub fn entry(&self) -> &gtk::Entry {
         self.imp().playlist_label_entry.as_ref()
-    }
-
-    pub fn set_grows_automatically(&self) {
-        let entry: &gtk::Entry = &self.imp().playlist_label_entry;
-        entry
-            .bind_property("text", entry, "width-chars")
-            .transform_to(|_, text: &str| Some(text.len() as i32))
-            .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE)
-            .build();
     }
 }


### PR DESCRIPTION
- The GtkEntry is now set to expand and fill the available space.
- The surrounding Box also does the same.
- I also had to remove the property binding which ensured, that the Entry has the same size as the text, which previously made it grow unbounded.

Closes #37 