### PR TITLE
Redid bottom bar UI to better suit small screens

### DIFF
--- a/src/app/components/playback/playback_widget.blp
+++ b/src/app/components/playback/playback_widget.blp
@@ -17,8 +17,6 @@ template $PlaybackWidget : Box {
   }
 
   Box {
-    margin-top: 0;
-    margin-bottom: 0;
     margin-start: 10;
     margin-end: 10;
 
@@ -48,117 +46,79 @@ template $PlaybackWidget : Box {
     width-request: 1;
     height-request: 1;
 
-    Adw.Breakpoint {
-      condition("max-width:700sp")
-
-      setters {
-        desktop-grid.column-homogeneous: false;
-        controls.halign: end;
-      }
-    }
-
+    /* Hide volume on small screens */
     Adw.Breakpoint {
       condition("max-width:600sp")
 
       setters {
-        volume-stack.visible-child-name: 'slider-button';
-        desktop-grid.column-homogeneous: false;
-        controls.halign: end;
+        volume-stack.visible: false;
       }
     }
 
-    child: Grid desktop-grid  {
-      halign: fill;
-      hexpand: true;
-      column-homogeneous: true;
-
-      $PlaybackInfoWidget now_playing {
-        receives-default: "1";
-        halign: "start";
-        valign: "center";
-        has-frame: "0";
-
-        layout {
-          column-span: "1";
-          column: "0";
-          row: "0";
-        }
+    Adw.Breakpoint {
+      condition("min-width:601sp")
+      setters {
+        volume-stack.visible: true;
       }
+    }
 
-      $PlaybackControlsWidget controls {
-        halign: center;
-        layout {
-          column-span: "1";
-          column: "1";
-          row: "0";
-        }
-      }
+    child: Box {
+      orientation: vertical;
+      spacing: 6;
+      margin-start: 10;
+      margin-end: 10;
+      margin-bottom: 8;
 
-      Stack volume-stack {
-        visible-child-name: "slider";
+      /* Top row */
+      Box {
+        spacing: 12;
         hexpand: true;
 
-        layout {
-          column-span: "1";
-          column: "2";
-          row: "0";
+        $PlaybackInfoWidget now_playing {
+          hexpand: true;
+          halign: start;
         }
 
-        StackPage {
-          name: 'slider';
-          child: Box {
-            Image {
-              icon-name: 'multimedia-volume-control-symbolic';
-            }
+        Stack volume-stack {
+          valign: center;
 
-            Scale volume_slider {
-              hexpand: true;
-              show-fill-level: true;
-              restrict-to-fill-level: false;
-              value-pos: left;
-              layout {
-                column-span: "1";
-                column: 2;
-                row: "0";
+          StackPage {
+
+            child: Box {
+              spacing: 6;
+
+              Image {
+                icon-name: 'multimedia-volume-control-symbolic';
+                accessible-role: presentation;
               }
 
-              styles [
-                'volume-slider'
-              ]
+              Scale volume_slider {
+                hexpand: true;
+                width-request: 120;
 
-              adjustment: Adjustment {
-                lower: 0.0;
-                value: 0.7;
-                upper: 1.0;
-                step-increment: 0.01;
-                page-increment: 0.05;
-              };
-            }
-          };
-        }
-
-        StackPage {
-          name: 'slider-button';
-          child: Box {
-            halign: end;
-            valign: center;
-            margin-end: 10;
-            MenuButton {
-              icon-name: 'multimedia-volume-control-symbolic';
-              halign: end;
-              styles [
-                "flat"
-              ]
-              popover: Popover{
-                child: Scale {
-                  inverted: true;
-                  orientation: vertical;
-                  height-request: 160;
-                  adjustment: bind volume_slider.adjustment;
+                adjustment: Adjustment {
+                  lower: 0.0;
+                  upper: 1.0;
+                  value: 0.7;
+                  step-increment: 0.01;
+                  page-increment: 0.05;
                 };
-              };
-            }
-          };
+
+                styles [
+                  "volume-slider"
+                ]
+              }
+            };
+          }
+        }
+      }
+
+      /* Bottom row */
+      Adw.Bin {
+        hexpand: true;
+
+        $PlaybackControlsWidget controls {
+          halign: center;
         }
       }
     };


### PR DESCRIPTION
Fixes: https://github.com/Diegovsky/riff/issues/75
Fixes: https://github.com/Diegovsky/riff/issues/30

This was the main issue I saw when using this on a phone screen. The bottom controls were clipped and the now playing widget was too small to read. I've redone the UI so that the controls are always in their own lower bar, with the now playing info on top, similar to spotify. In larger screen sizes a volume slider is visible.
Before:
<img width="666" height="183" alt="image" src="https://github.com/user-attachments/assets/3a9bcbbf-e9f0-49f5-8738-7776c7d49545" />
After, small screen:
<img width="726" height="252" alt="image" src="https://github.com/user-attachments/assets/27dc5ffb-a376-4f4e-a01c-67959379a5eb" />
After, large screen:
<img width="1358" height="307" alt="image" src="https://github.com/user-attachments/assets/7ea078e8-9a63-4223-808e-ba8b5a525dee" />
