### PR TITLE
Added context menu for playlists in sidebar

### DIFF
--- a/src/api/cached_client.rs
+++ b/src/api/cached_client.rs
@@ -67,6 +67,8 @@ pub trait SpotifyApiClient {
 
     fn remove_from_playlist(&self, id: &str, uris: Vec<String>) -> BoxFuture<SpotifyResult<()>>;
 
+    fn unfollow_playlist(&self, id: &str) -> BoxFuture<SpotifyResult<()>>;
+
     fn update_playlist_details(&self, id: &str, name: String) -> BoxFuture<SpotifyResult<()>>;
 
     fn search(
@@ -175,6 +177,8 @@ impl RiffCacheKey<'_> {
 lazy_static! {
     pub static ref ME_TRACKS_CACHE: Regex = Regex::new(r"^me_tracks_\w+_\w+\.json$").unwrap();
     pub static ref ME_ALBUMS_CACHE: Regex = Regex::new(r"^me_albums_\w+_\w+\.json$").unwrap();
+    pub static ref ME_PLAYLISTS_CACHE: Regex =
+        Regex::new(r"^me_playlists_\w+_\w+\.json$").unwrap();
     pub static ref USER_CACHE: Regex =
         Regex::new(r"^me_(albums|playlists|tracks)_\w+_\w+\.json$").unwrap();
 }
@@ -382,6 +386,21 @@ impl SpotifyApiClient for CachedSpotifyClient {
 
             self.client
                 .remove_from_playlist(&id, uris)
+                .send_no_response()
+                .await?;
+            Ok(())
+        })
+    }
+
+    fn unfollow_playlist(&self, id: &str) -> BoxFuture<SpotifyResult<()>> {
+        let id = id.to_owned();
+
+        Box::pin(async move {
+            let _ = self.cache.set_expired_pattern(&ME_PLAYLISTS_CACHE).await;
+            let _ = self.cache.set_expired_pattern(&playlist_cache_key(&id)).await;
+
+            self.client
+                .unfollow_playlist(&id)
                 .send_no_response()
                 .await?;
             Ok(())

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -431,6 +431,12 @@ impl SpotifyClient {
             .json_body(Uris { uris })
     }
 
+    pub(crate) fn unfollow_playlist(&self, id: &str) -> SpotifyRequest<'_, (), ()> {
+        self.request()
+            .method(Method::DELETE)
+            .uri(format!("/v1/playlists/{id}/followers"), None)
+    }
+
     pub(crate) fn update_playlist_details(
         &self,
         playlist: &str,

--- a/src/app/components/labels.rs
+++ b/src/app/components/labels.rs
@@ -12,6 +12,12 @@ lazy_static! {
 
     // translators: This is part of a contextual menu attached to a single track; this entry removes a track from the play queue.
     pub static ref REMOVE_FROM_QUEUE: String = gettext("Remove from queue");
+
+    // translators: This is part of a contextual menu attached to a playlist in the sidebar; this entry deletes a playlist owned by the user.
+    pub static ref DELETE_PLAYLIST: String = gettext("Delete playlist");
+
+    // translators: This is part of a contextual menu attached to a playlist in the sidebar; this entry unfollows a playlist the user does not own.
+    pub static ref UNFOLLOW_PLAYLIST: String = gettext("Unfollow playlist");
 }
 
 pub fn add_to_playlist_label(playlist: &str) -> String {

--- a/src/app/components/playlist_details/playlist_details_model.rs
+++ b/src/app/components/playlist_details/playlist_details_model.rs
@@ -34,7 +34,7 @@ impl PlaylistDetailsModel {
 
     pub fn is_playlist_editable(&self) -> bool {
         let state = self.app_model.get_state();
-        state.logged_user.playlists.iter().any(|p| p.id == self.id)
+        state.logged_user.playlist_ids.contains(&self.id)
     }
 
     pub fn get_playlist_info(&self) -> Option<impl Deref<Target = PlaylistDescription> + '_> {

--- a/src/app/components/sidebar/mod.rs
+++ b/src/app/components/sidebar/mod.rs
@@ -6,4 +6,5 @@ mod sidebar_item;
 pub use sidebar_item::*;
 
 mod create_playlist;
+mod playlist_actions;
 mod sidebar_row;

--- a/src/app/components/sidebar/playlist_actions.rs
+++ b/src/app/components/sidebar/playlist_actions.rs
@@ -1,0 +1,50 @@
+use gdk::prelude::*;
+use gio::SimpleActionGroup;
+use std::rc::Rc;
+
+use super::SidebarModel;
+use crate::app::components::labels;
+
+fn make_copy_link_action(id: &str) -> gio::SimpleAction {
+    let action = gio::SimpleAction::new("copy_link", None);
+    let id = id.to_owned();
+    action.connect_activate(move |_, _| {
+        let link = format!("https://open.spotify.com/playlist/{id}");
+        let clipboard = gdk::Display::default().unwrap().clipboard();
+        clipboard
+            .set_content(Some(&gdk::ContentProvider::for_value(&link.to_value())))
+            .expect("Failed to set clipboard content");
+    });
+    action
+}
+
+fn make_unfollow_action(id: &str, model: &Rc<SidebarModel>) -> gio::SimpleAction {
+    let action = gio::SimpleAction::new("unfollow", None);
+    let id = id.to_owned();
+    action.connect_activate(clone!(
+        #[weak]
+        model,
+        move |_, _| {
+            model.unfollow_playlist(id.clone());
+        }
+    ));
+    action
+}
+
+pub fn build_playlist_actions(id: &str, model: &Rc<SidebarModel>) -> SimpleActionGroup {
+    let group = SimpleActionGroup::new();
+    group.add_action(&make_copy_link_action(id));
+    group.add_action(&make_unfollow_action(id, model));
+    group
+}
+
+pub fn build_playlist_menu(is_owned: bool) -> gio::Menu {
+    let menu = gio::Menu::new();
+    menu.append(Some(&*labels::COPY_LINK), Some("playlist.copy_link"));
+    if is_owned {
+        menu.append(Some(&*labels::DELETE_PLAYLIST), Some("playlist.unfollow"));
+    } else {
+        menu.append(Some(&*labels::UNFOLLOW_PLAYLIST), Some("playlist.unfollow"));
+    }
+    menu
+}

--- a/src/app/components/sidebar/sidebar.rs
+++ b/src/app/components/sidebar/sidebar.rs
@@ -1,11 +1,13 @@
 use gettextrs::gettext;
 use gtk::prelude::*;
+use std::cell::RefCell;
 use std::rc::Rc;
 
-use super::create_playlist::CreatePlaylistPopover;
 use super::{
-    sidebar_row::SidebarRow, SidebarDestination, SidebarItem, CREATE_PLAYLIST_ITEM,
-    SAVED_PLAYLISTS_SECTION,
+    create_playlist::CreatePlaylistPopover,
+    playlist_actions,
+    sidebar_row::SidebarRow,
+    SidebarDestination, SidebarItem, CREATE_PLAYLIST_ITEM, SAVED_PLAYLISTS_SECTION,
 };
 use crate::app::models::{AlbumModel, PlaylistSummary};
 use crate::app::state::ScreenName;
@@ -62,6 +64,23 @@ impl SidebarModel {
             })
     }
 
+    pub(super) fn is_playlist_owned(&self, id: &str) -> bool {
+        self.app_model
+            .get_state()
+            .logged_user
+            .playlist_ids
+            .contains(id)
+    }
+
+    pub(super) fn unfollow_playlist(&self, id: String) {
+        let api = self.app_model.get_spotify();
+        self.dispatcher
+            .call_spotify_and_dispatch(move || async move {
+                api.unfollow_playlist(&id).await?;
+                Ok(AppAction::RemovePlaylist(id))
+            })
+    }
+
     fn navigate(&self, dest: SidebarDestination) {
         let actions = match dest {
             SidebarDestination::Library
@@ -85,6 +104,7 @@ pub struct Sidebar {
     listbox: gtk::ListBox,
     list_store: gio::ListStore,
     model: Rc<SidebarModel>,
+    _context_menu: gtk::PopoverMenu,
 }
 
 impl Sidebar {
@@ -151,10 +171,86 @@ impl Sidebar {
             }
         ));
 
+        let context_menu = gtk::PopoverMenu::from_model(None::<&gio::MenuModel>);
+        context_menu.set_parent(&listbox);
+        context_menu.set_has_arrow(false);
+
+        let context_row: Rc<RefCell<Option<SidebarRow>>> = Default::default();
+
+        context_menu.connect_closed(clone!(
+            #[strong]
+            context_row,
+            move |_| {
+                if let Some(row) = context_row.borrow_mut().take() {
+                    row.unset_state_flags(gtk::StateFlags::SELECTED);
+                }
+            }
+        ));
+
+        let show_context_menu = clone!(
+            #[weak]
+            listbox,
+            #[weak]
+            model,
+            #[weak]
+            context_menu,
+            #[strong]
+            context_row,
+            move |x: f64, y: f64| {
+                let Some(row) = listbox.row_at_y(y as i32) else {
+                    return;
+                };
+                let Some(row) = row.downcast_ref::<SidebarRow>() else {
+                    return;
+                };
+                let Some(SidebarDestination::Playlist(PlaylistSummary { id, .. })) =
+                    row.item().destination()
+                else {
+                    return;
+                };
+
+                row.set_state_flags(gtk::StateFlags::SELECTED, false);
+                context_row.replace(Some(row.clone()));
+
+                let actions = playlist_actions::build_playlist_actions(&id, &model);
+                listbox.insert_action_group("playlist", Some(&actions));
+
+                let is_owned = model.is_playlist_owned(&id);
+                context_menu.set_menu_model(Some(&playlist_actions::build_playlist_menu(is_owned)));
+
+                let rect = gdk::Rectangle::new(x as i32, y as i32, 1, 1);
+                context_menu.set_pointing_to(Some(&rect));
+                context_menu.popup();
+            }
+        );
+
+        let right_click = gtk::GestureClick::new();
+        right_click.set_button(3);
+        right_click.connect_pressed(clone!(
+            #[strong]
+            show_context_menu,
+            move |_, _, x, y| {
+                show_context_menu(x, y);
+            }
+        ));
+        listbox.add_controller(right_click);
+
+        let long_press = gtk::GestureLongPress::new();
+        long_press.set_touch_only(false);
+        long_press.connect_pressed(clone!(
+            #[strong]
+            show_context_menu,
+            move |_, x, y| {
+                show_context_menu(x, y);
+            }
+        ));
+        listbox.add_controller(long_press);
+
         Self {
             listbox,
             list_store,
             model,
+            _context_menu: context_menu,
         }
     }
 

--- a/src/app/state/app_state.rs
+++ b/src/app/state/app_state.rs
@@ -37,6 +37,7 @@ pub enum AppAction {
     CancelSelection,
     CreatePlaylist(PlaylistDescription),
     UpdatePlaylistName(PlaylistSummary),
+    RemovePlaylist(String),
 }
 
 // Not actual actions, just neat wrappers
@@ -240,6 +241,18 @@ impl AppState {
                 );
                 let mut more_events =
                     forward_action(BrowserAction::UpdatePlaylistName(s), &mut self.browser);
+                events.append(&mut more_events);
+                events
+            }
+            AppAction::RemovePlaylist(id) => {
+                let mut events = forward_action(
+                    LoginAction::RemoveUserPlaylist(id.clone()),
+                    &mut self.logged_user,
+                );
+                let mut more_events = forward_action(
+                    BrowserAction::RemovePlaylist(id),
+                    &mut self.browser,
+                );
                 events.append(&mut more_events);
                 events
             }

--- a/src/app/state/browser_state.rs
+++ b/src/app/state/browser_state.rs
@@ -17,6 +17,7 @@ pub enum BrowserAction {
     SetPlaylistsContent(Vec<PlaylistDescription>),
     AppendPlaylistsContent(Vec<PlaylistDescription>),
     RemoveTracksFromPlaylist(String, Vec<String>),
+    RemovePlaylist(String),
     SetAlbumDetails(Box<AlbumFullDescription>),
     AppendAlbumTracks(String, Box<SongBatch>),
     SetPlaylistDetails(Box<PlaylistDescription>, Box<SongBatch>),

--- a/src/app/state/login_state.rs
+++ b/src/app/state/login_state.rs
@@ -1,5 +1,6 @@
 use gettextrs::*;
 use std::borrow::Cow;
+use std::collections::HashSet;
 use url::Url;
 
 use crate::app::models::PlaylistSummary;
@@ -21,6 +22,7 @@ pub enum LoginAction {
     SetUserPlaylists(Vec<PlaylistSummary>),
     UpdateUserPlaylist(PlaylistSummary),
     PrependUserPlaylist(Vec<PlaylistSummary>),
+    RemoveUserPlaylist(String),
     SetLoginFailure,
     RefreshToken,
     TokenRefreshed,
@@ -65,6 +67,8 @@ pub struct LoginState {
     pub user: Option<String>,
     // Playlists owned by the logged in user
     pub playlists: Vec<PlaylistSummary>,
+    // Playlist IDs for O(1) ownership checks
+    pub playlist_ids: HashSet<String>,
 }
 
 impl UpdatableState for LoginState {
@@ -103,6 +107,7 @@ impl UpdatableState for LoginState {
                 vec![LoginEvent::LogoutCompleted.into()]
             }
             LoginAction::SetUserPlaylists(playlists) => {
+                self.playlist_ids = playlists.iter().map(|p| p.id.clone()).collect();
                 self.playlists = playlists;
                 vec![LoginEvent::UserPlaylistsLoaded.into()]
             }
@@ -113,8 +118,16 @@ impl UpdatableState for LoginState {
                 vec![LoginEvent::UserPlaylistsLoaded.into()]
             }
             LoginAction::PrependUserPlaylist(mut summaries) => {
+                for s in &summaries {
+                    self.playlist_ids.insert(s.id.clone());
+                }
                 summaries.append(&mut self.playlists);
                 self.playlists = summaries;
+                vec![LoginEvent::UserPlaylistsLoaded.into()]
+            }
+            LoginAction::RemoveUserPlaylist(id) => {
+                self.playlists.retain(|p| p.id != id);
+                self.playlist_ids.remove(&id);
                 vec![LoginEvent::UserPlaylistsLoaded.into()]
             }
             LoginAction::TryLogin(TryLoginAction::InitLogin) => {

--- a/src/app/state/screen_states.rs
+++ b/src/app/state/screen_states.rs
@@ -293,6 +293,16 @@ impl UpdatableState for HomeState {
                 }
                 vec![BrowserEvent::SavedPlaylistsUpdated]
             }
+            BrowserAction::RemovePlaylist(id) => {
+                let position = self.playlists.iter().position(|p| p.uri() == *id);
+                if let Some(position) = position {
+                    self.playlists.remove(position as u32);
+                    self.next_playlists_page.decrement();
+                    vec![BrowserEvent::SavedPlaylistsUpdated]
+                } else {
+                    vec![]
+                }
+            }
             BrowserAction::AppendSavedTracks(song_batch) => {
                 if self.saved_tracks.add(*song_batch.clone()).commit() {
                     vec![BrowserEvent::SavedTracksUpdated]


### PR DESCRIPTION
## Summary

Adds a context menu to playlists in the sidebar, triggered by right-click or long-press. The menu provides "Copy link" and "Unfollow/Delete playlist" actions.

## Changes

- **API layer**: Added `unfollow_playlist` endpoint (`DELETE /playlists/{id}/followers`) with playlist cache invalidation via a new `ME_PLAYLISTS_CACHE` regex.
- **Sidebar UI**: Added `PopoverMenu` context menu to the sidebar listbox, triggered by `GestureClick` (right click) and `GestureLongPress`. The menu highlights the target row while open and clears the selection on close.
- **Playlist actions**: New `playlist_actions` module builds the action group and menu model. Shows "Delete playlist" for owned playlists and "Unfollow playlist" for followed ones.
- **State management**: Added `RemovePlaylist` action that propagates through `AppState` → `BrowserState` (removes from playlist list) and `LoginState` (removes from user playlists). Added `playlist_ids: HashSet<String>` to `LoginState` for O(1) ownership checks, replacing the previous linear scan in `PlaylistDetailsModel`.
- **Labels**: Added translatable `DELETE_PLAYLIST` and `UNFOLLOW_PLAYLIST` strings.

## Testing

- [X] Right-click on a playlist shows context menu
- [X] "Copy link" copies `https://open.spotify.com/playlist/{id}` to clipboard
- [X] "Delete playlist" shown for owned playlists, "Unfollow playlist" for others
- [X] Unfollowing removes the playlist from the sidebar and from the user's Spotify account
- [ ] Long-press works on touch devices

## Gif 
<img width="338" height="448" alt="Screencast From 2026-05-03 20-22-35" src="https://github.com/user-attachments/assets/a972865d-4f6a-4692-b963-428cb5d662ac" />
