### PR TITLE
Fix double hover highlight on album and artist cards

### DIFF
--- a/src/app/components/album/album.blp
+++ b/src/app/components/album/album.blp
@@ -2,71 +2,62 @@ using Gtk 4.0;
 using Adw 1;
 
 template $AlbumWidget : Adw.Bin {
-  Button cover_btn {
+  Box {
     hexpand: false;
     halign: center;
     valign: start;
+    margin-top: 6;
+    margin-bottom: 6;
+    orientation: vertical;
+    spacing: 6;
 
-    Box {
-      halign: center;
-      valign: start;
-      margin-top: 6;
-      margin-bottom: 6;
-      orientation: vertical;
-      spacing: 6;
+    Picture cover_image {
+      content-fit: cover;
 
-      Picture cover_image {
-        content-fit: cover;
-
-        styles [
-          "card",
-        ]
-      }
-
-      Label album_label {
-        label: "Album";
-        justify: center;
-        wrap: true;
-        wrap-mode: word;
-        ellipsize: end;
-        max-width-chars: 1;
-        margin-top: 6;
-
-        styles [
-          "title-4",
-        ]
-      }
-
-      Label artist_label {
-        label: "Artist";
-        justify: center;
-        wrap: true;
-        wrap-mode: word;
-        ellipsize: end;
-        max-width-chars: 1;
-
-        styles [
-          "body",
-        ]
-      }
-
-      Label year_label {
-        label: "Year";
-        justify: center;
-        wrap: true;
-        wrap-mode: word_char;
-        max-width-chars: 1;
-        sensitive: false;
-
-        styles [
-          "body",
-        ]
-      }
+      styles [
+        "card",
+      ]
     }
 
-    styles [
-      "flat",
-    ]
+    Label album_label {
+      label: "Album";
+      justify: center;
+      wrap: true;
+      wrap-mode: word;
+      ellipsize: end;
+      max-width-chars: 1;
+      margin-top: 6;
+
+      styles [
+        "title-4",
+      ]
+    }
+
+    Label artist_label {
+      label: "Artist";
+      justify: center;
+      wrap: true;
+      wrap-mode: word;
+      ellipsize: end;
+      max-width-chars: 1;
+
+      styles [
+        "body",
+      ]
+    }
+
+    Label year_label {
+      label: "Year";
+      justify: center;
+      wrap: true;
+      wrap-mode: word_char;
+      max-width-chars: 1;
+      sensitive: false;
+
+      styles [
+        "body",
+      ]
+    }
   }
 
   styles [

--- a/src/app/components/album/album.css
+++ b/src/app/components/album/album.css
@@ -11,9 +11,6 @@ navigation-split-view .album {
   margin-bottom: 6px;
 }
 
-navigation-split-view .album button {
- border-radius: 12px;
-}
 /* small style */
 
 navigation-split-view.collapsed .album .card {
@@ -27,8 +24,4 @@ navigation-split-view.collapsed .album .card {
 navigation-split-view .album {
   margin-top: 0px;
   margin-bottom: 0px;
-}
-
-navigation-split-view.collapsed .album button {
- border-radius: 6px;
 }

--- a/src/app/components/album/album.rs
+++ b/src/app/components/album/album.rs
@@ -25,9 +25,6 @@ mod imp {
         pub year_label: TemplateChild<gtk::Label>,
 
         #[template_child]
-        pub cover_btn: TemplateChild<gtk::Button>,
-
-        #[template_child]
         pub cover_image: TemplateChild<gtk::Picture>,
     }
 
@@ -120,11 +117,5 @@ impl AlbumWidget {
         } else {
             widget.year_label.set_visible(false);
         }
-    }
-
-    pub fn connect_album_pressed<F: Fn() + 'static>(&self, f: F) {
-        self.imp().cover_btn.connect_clicked(move |_| {
-            f();
-        });
     }
 }

--- a/src/app/components/artist/artist.blp
+++ b/src/app/components/artist/artist.blp
@@ -4,14 +4,12 @@ using Adw 1;
 template $ArtistWidget : Box {
   orientation: vertical;
 
-  Button avatar_btn {
+  Box {
     vexpand: true;
     width-request: 150;
     height-request: 150;
-    receives-default: true;
     halign: center;
     valign: center;
-    has-frame: false;
 
     Adw.Avatar avatar {
       halign: center;
@@ -19,10 +17,6 @@ template $ArtistWidget : Box {
       show-initials: true;
       size: 150;
     }
-
-    styles [
-      "circular",
-    ]
   }
 
   Label artist {

--- a/src/app/components/artist/mod.rs
+++ b/src/app/components/artist/mod.rs
@@ -17,9 +17,6 @@ mod imp {
         pub artist: TemplateChild<gtk::Label>,
 
         #[template_child]
-        pub avatar_btn: TemplateChild<gtk::Button>,
-
-        #[template_child]
         pub avatar: TemplateChild<libadwaita::Avatar>,
     }
 
@@ -62,12 +59,6 @@ impl ArtistWidget {
         let _self = Self::new();
         _self.bind(model, worker);
         _self
-    }
-
-    pub fn connect_artist_pressed<F: Fn() + 'static>(&self, f: F) {
-        self.imp().avatar_btn.connect_clicked(move |_| {
-            f();
-        });
     }
 
     fn bind(&self, model: &ArtistModel, worker: Worker) {

--- a/src/app/components/artist_details/artist_details.blp
+++ b/src/app/components/artist_details/artist_details.blp
@@ -44,7 +44,7 @@ template $ArtistDetailsWidget : Box {
           hexpand: true;
           min-children-per-line: 1;
           selection-mode: none;
-          activate-on-single-click: false;
+          activate-on-single-click: true;
         }
 
         [label]

--- a/src/app/components/artist_details/artist_details.rs
+++ b/src/app/components/artist_details/artist_details.rs
@@ -3,6 +3,7 @@ use gtk::subclass::prelude::*;
 use gtk::CompositeTemplate;
 use std::rc::Rc;
 
+use crate::app::components::utils::wrap_flowbox_item;
 use crate::app::components::{
     display_add_css_provider, AlbumWidget, Component, EventListener, Playlist,
 };
@@ -87,22 +88,19 @@ impl ArtistDetailsWidget {
     ) where
         F: Fn(String) + Clone + 'static,
     {
+        let store_clone = store.clone();
         self.imp()
             .artist_releases
             .bind_model(Some(store.inner()), move |item| {
-                let item = item.downcast_ref::<AlbumModel>().unwrap();
-                let child = gtk::FlowBoxChild::new();
-                let album = AlbumWidget::for_model(item, worker.clone());
-                let f = on_album_pressed.clone();
-                album.connect_album_pressed(clone!(
-                    #[weak]
-                    item,
-                    move || {
-                        f(item.uri());
-                    }
-                ));
-                child.set_child(Some(&album));
-                child.upcast::<gtk::Widget>()
+                wrap_flowbox_item(item, |album_model: &AlbumModel| {
+                    AlbumWidget::for_model(album_model, worker.clone())
+                })
+            });
+        self.imp()
+            .artist_releases
+            .connect_child_activated(move |_, child| {
+                let album_model = store_clone.get(child.index() as u32);
+                on_album_pressed(album_model.uri());
             });
     }
 }

--- a/src/app/components/library/library.blp
+++ b/src/app/components/library/library.blp
@@ -15,7 +15,7 @@ template $LibraryWidget : Box {
         margin-bottom: 6;
         min-children-per-line: 1;
         selection-mode: none;
-        activate-on-single-click: false;
+        activate-on-single-click: true;
       }
 
       [overlay]

--- a/src/app/components/library/library.rs
+++ b/src/app/components/library/library.rs
@@ -80,21 +80,19 @@ impl LibraryWidget {
     where
         F: Fn(String) + Clone + 'static,
     {
+        let store_clone = store.clone();
         self.imp()
             .flowbox
             .bind_model(Some(store.inner()), move |item| {
-                wrap_flowbox_item(item, |album_model| {
-                    let f = on_album_pressed.clone();
-                    let album = AlbumWidget::for_model(album_model, worker.clone());
-                    album.connect_album_pressed(clone!(
-                        #[weak]
-                        album_model,
-                        move || {
-                            f(album_model.uri());
-                        }
-                    ));
-                    album
+                wrap_flowbox_item(item, |album_model: &AlbumModel| {
+                    AlbumWidget::for_model(album_model, worker.clone())
                 })
+            });
+        self.imp()
+            .flowbox
+            .connect_child_activated(move |_, child| {
+                let album_model = store_clone.get(child.index() as u32);
+                on_album_pressed(album_model.uri());
             });
     }
 

--- a/src/app/components/saved_playlists/saved_playlists.blp
+++ b/src/app/components/saved_playlists/saved_playlists.blp
@@ -16,7 +16,7 @@ template $SavedPlaylistsWidget : Box {
         margin-bottom: 8;
         min-children-per-line: 1;
         selection-mode: none;
-        activate-on-single-click: false;
+        activate-on-single-click: true;
       }
 
       [overlay]

--- a/src/app/components/saved_playlists/saved_playlists.rs
+++ b/src/app/components/saved_playlists/saved_playlists.rs
@@ -4,6 +4,7 @@ use gtk::CompositeTemplate;
 use std::rc::Rc;
 
 use super::SavedPlaylistsModel;
+use crate::app::components::utils::wrap_flowbox_item;
 use crate::app::components::{AlbumWidget, Component, EventListener};
 use crate::app::dispatch::Worker;
 use crate::app::models::AlbumModel;
@@ -78,24 +79,19 @@ impl SavedPlaylistsWidget {
     where
         F: Fn(String) + Clone + 'static,
     {
+        let store_clone = store.clone();
         self.imp()
             .flowbox
             .bind_model(Some(store.inner()), move |item| {
-                let album_model = item.downcast_ref::<AlbumModel>().unwrap();
-                let child = gtk::FlowBoxChild::new();
-                let album = AlbumWidget::for_model(album_model, worker.clone());
-
-                let f = on_album_pressed.clone();
-                album.connect_album_pressed(clone!(
-                    #[weak]
-                    album_model,
-                    move || {
-                        f(album_model.uri());
-                    }
-                ));
-
-                child.set_child(Some(&album));
-                child.upcast::<gtk::Widget>()
+                wrap_flowbox_item(item, |album_model: &AlbumModel| {
+                    AlbumWidget::for_model(album_model, worker.clone())
+                })
+            });
+        self.imp()
+            .flowbox
+            .connect_child_activated(move |_, child| {
+                let album_model = store_clone.get(child.index() as u32);
+                on_album_pressed(album_model.uri());
             });
     }
     pub fn get_status_page(&self) -> &libadwaita::StatusPage {

--- a/src/app/components/search/search.blp
+++ b/src/app/components/search/search.blp
@@ -59,7 +59,7 @@ template $SearchResultsWidget : Box {
               orientation: vertical;
               max-children-per-line: 1;
               selection-mode: none;
-              activate-on-single-click: false;
+              activate-on-single-click: true;
             }
           }
 
@@ -90,7 +90,7 @@ template $SearchResultsWidget : Box {
               orientation: vertical;
               max-children-per-line: 1;
               selection-mode: none;
-              activate-on-single-click: false;
+              activate-on-single-click: true;
             }
           }
 

--- a/src/app/components/search/search.rs
+++ b/src/app/components/search/search.rs
@@ -109,21 +109,23 @@ impl SearchResultsWidget {
     where
         F: Fn(String) + Clone + 'static,
     {
+        let store_clone = store.clone();
         self.imp()
             .albums_results
             .bind_model(Some(store), move |item| {
-                wrap_flowbox_item(item, |album_model| {
-                    let f = on_album_pressed.clone();
-                    let album = AlbumWidget::for_model(album_model, worker.clone());
-                    album.connect_album_pressed(clone!(
-                        #[weak]
-                        album_model,
-                        move || {
-                            f(album_model.uri());
-                        }
-                    ));
-                    album
+                wrap_flowbox_item(item, |album_model: &AlbumModel| {
+                    AlbumWidget::for_model(album_model, worker.clone())
                 })
+            });
+        self.imp()
+            .albums_results
+            .connect_child_activated(move |_, child| {
+                let index = child.index() as u32;
+                if let Some(item) = store_clone.item(index) {
+                    if let Some(album_model) = item.downcast_ref::<AlbumModel>() {
+                        on_album_pressed(album_model.uri());
+                    }
+                }
             });
     }
 
@@ -131,21 +133,23 @@ impl SearchResultsWidget {
     where
         F: Fn(String) + Clone + 'static,
     {
+        let store_clone = store.clone();
         self.imp()
             .artist_results
             .bind_model(Some(store), move |item| {
-                wrap_flowbox_item(item, |artist_model| {
-                    let f = on_artist_pressed.clone();
-                    let artist = ArtistWidget::for_model(artist_model, worker.clone());
-                    artist.connect_artist_pressed(clone!(
-                        #[weak]
-                        artist_model,
-                        move || {
-                            f(artist_model.id());
-                        }
-                    ));
-                    artist
+                wrap_flowbox_item(item, |artist_model: &ArtistModel| {
+                    ArtistWidget::for_model(artist_model, worker.clone())
                 })
+            });
+        self.imp()
+            .artist_results
+            .connect_child_activated(move |_, child| {
+                let index = child.index() as u32;
+                if let Some(item) = store_clone.item(index) {
+                    if let Some(artist_model) = item.downcast_ref::<ArtistModel>() {
+                        on_artist_pressed(artist_model.id());
+                    }
+                }
             });
     }
 }

--- a/src/app/components/user_details/user_details.blp
+++ b/src/app/components/user_details/user_details.blp
@@ -33,7 +33,7 @@ template $UserDetailsWidget : Box {
         hexpand: true;
         min-children-per-line: 1;
         selection-mode: none;
-        activate-on-single-click: false;
+        activate-on-single-click: true;
       }
     }
   }

--- a/src/app/components/user_details/user_details.rs
+++ b/src/app/components/user_details/user_details.rs
@@ -79,21 +79,19 @@ impl UserDetailsWidget {
     where
         F: Fn(String) + Clone + 'static,
     {
+        let store_clone = store.clone();
         self.imp()
             .user_playlists
             .bind_model(Some(store.inner()), move |item| {
-                wrap_flowbox_item(item, |item: &AlbumModel| {
-                    let f = on_pressed.clone();
-                    let album = AlbumWidget::for_model(item, worker.clone());
-                    album.connect_album_pressed(clone!(
-                        #[weak]
-                        item,
-                        move || {
-                            f(item.uri());
-                        }
-                    ));
-                    album
+                wrap_flowbox_item(item, |album_model: &AlbumModel| {
+                    AlbumWidget::for_model(album_model, worker.clone())
                 })
+            });
+        self.imp()
+            .user_playlists
+            .connect_child_activated(move |_, child| {
+                let album_model = store_clone.get(child.index() as u32);
+                on_pressed(album_model.uri());
             });
     }
 }


### PR DESCRIPTION
## Summary

Fixes the double mouseover highlight on album/playlist and artist cards in the library, saved playlists, search, artist details, and user details views.

## Problem

Each card was wrapped in a `FlowBoxChild` (which has its own hover state) and also contained a `Button` (which has its own hover state). On mouseover, both layers showed a highlight simultaneously.

## Changes

- Replaced `Button` with `Box` in `AlbumWidget` and `ArtistWidget` templates, making them display-only
- Removed `connect_album_pressed` and `connect_artist_pressed` methods
- Moved click handling to `FlowBox::connect_child_activated` at the parent level
- Set `activate-on-single-click: true` on all affected FlowBox widgets
- Removed now-unused `button` CSS rules from `album.css`

## Testing

- [x] Hover over album/playlist cards in library, saved playlists, search, artist details, and user details — only a single highlight appears
- [x] Click cards to verify navigation still works

## Images

__New__
<img width="776" height="348" alt="Screencast From 2026-05-03 21-18-41" src="https://github.com/user-attachments/assets/733252b7-45aa-41e5-9756-2318bb77faee" />


__Old__
<img width="776" height="350" alt="Screencast From 2026-05-03 21-20-12" src="https://github.com/user-attachments/assets/75b0faa0-1ea2-4cda-b1aa-a702eff09998" />
