### PR TITLE
Fix play button error on albums/playlists by reading from SongListModel

### DIFF
--- a/src/app/components/details/details_model.rs
+++ b/src/app/components/details/details_model.rs
@@ -1,3 +1,4 @@
+use gettextrs::gettext;
 use gio::prelude::*;
 use gio::SimpleActionGroup;
 use std::cell::Ref;
@@ -110,14 +111,24 @@ impl DetailsModel {
     }
 
     pub fn toggle_play_album(&self) {
-        if let Some(album) = self.get_album_description() {
+        if self.get_album_description().is_some() {
             if !self.album_is_playing() {
                 if self.state().playback.is_shuffled() {
                     self.dispatcher
                         .dispatch(AppAction::PlaybackAction(PlaybackAction::ToggleShuffle));
                 }
-                let id_of_first_song = album.songs.songs[0].id.as_str();
-                self.play_song_at(0, id_of_first_song);
+
+                let first_song = self.song_list_model().index(0);
+                let Some(first_song) = first_song else {
+                    error!("Unable to start playback because the song list is empty");
+                    self.dispatcher
+                        .dispatch(AppAction::ShowNotification(gettext(
+                            "An error occured. Check logs for details!",
+                        )));
+                    return;
+                };
+
+                self.play_song_at(0, &first_song.get_id());
                 return;
             }
             if self.state().playback.is_playing() {

--- a/src/app/components/playlist_details/playlist_details_model.rs
+++ b/src/app/components/playlist_details/playlist_details_model.rs
@@ -57,25 +57,24 @@ impl PlaylistDetailsModel {
     }
 
     pub fn toggle_play_playlist(&self) {
-        if let Some(playlist) = self.get_playlist_info() {
+        if self.get_playlist_info().is_some() {
             if !self.playlist_is_playing() {
                 if self.state().playback.is_shuffled() {
                     self.dispatcher
                         .dispatch(AppAction::PlaybackAction(PlaybackAction::ToggleShuffle));
                 }
-                // The playlist has no songs and the user has still decided to click the play button,
-                // lets just do an early return and show an error...
-                if playlist.songs.songs.is_empty() {
-                    error!("Unable to start playback because songs is empty");
+
+                let first_song = self.song_list_model().index(0);
+                let Some(first_song) = first_song else {
+                    error!("Unable to start playback because the song list is empty");
                     self.dispatcher
                         .dispatch(AppAction::ShowNotification(gettext(
                             "An error occured. Check logs for details!",
                         )));
                     return;
-                }
+                };
 
-                let id_of_first_song = playlist.songs.songs[0].id.as_str();
-                self.play_song_at(0, id_of_first_song);
+                self.play_song_at(0, &first_song.get_id());
                 return;
             }
             if self.state().playback.is_playing() {


### PR DESCRIPTION
## Summary

Fixes intermittent error when clicking the play button after navigating to a new album or playlist.

## Problem

`toggle_play_album` and `toggle_play_playlist` read the first song's ID from the description object (`album.songs.songs[0]` / `playlist.songs.songs[0]`), but `play_song_at` reads from the `SongListModel`. These are populated from different sources:

- For playlists, `PlaylistDescription.songs` comes from the embedded tracks page in the `/playlists/{id}` response, while the `SongListModel` is populated from the separate `get_playlist_tracks()` call. The embedded page filters out local/unavailable tracks, so it can be empty even when the playlist has playable songs — triggering a false "An error occured" notification.
- For albums, the same mismatch existed, plus `album.songs.songs[0]` had no bounds check and could panic on an empty song list.

## Fix

Read the first song from `self.song_list_model().index(0)`, the same data source that `play_song_at` uses, instead of from the description's embedded songs. Added an empty check for albums that was previously missing.

## Testing
- [X] Click play on a newly navigated album before it finishes loading → no error
- [X] Click play on a newly navigated playlist before it finishes loading → no error
- [X] Click play on a playlist containing local files → plays without error
- [X] Play/pause/resume works on both albums and playlists
- [X] Playing album A, click play on album B → switches correctly