### PR TITLE
Prevent sticky focus highlight on header buttons

### DIFF
--- a/src/app/components/headerbar/headerbar.blp
+++ b/src/app/components/headerbar/headerbar.blp
@@ -16,6 +16,8 @@ template $HeaderBarWidget : Adw.Bin {
         valign: center;
         icon-name: "go-previous-symbolic";
         has-frame: false;
+        focus-on-click: false;
+        can-focus: false;
       }
 
       [title]
@@ -27,6 +29,8 @@ template $HeaderBarWidget : Adw.Bin {
       [end]
       Button start_selection {
         icon-name: "object-select-symbolic";
+        focus-on-click: false;
+        can-focus: false;
       }
     }
 

--- a/src/app/components/playlist_details/playlist_headerbar.blp
+++ b/src/app/components/playlist_details/playlist_headerbar.blp
@@ -16,6 +16,8 @@ template $PlaylistHeaderBarWidget : Adw.Bin {
         valign: center;
         icon-name: "go-previous-symbolic";
         has-frame: false;
+        focus-on-click: false;
+        can-focus: false;
       }
 
       [title]
@@ -27,6 +29,8 @@ template $PlaylistHeaderBarWidget : Adw.Bin {
       [end]
       Button edit {
         icon-name: "document-edit-symbolic";
+        focus-on-click: false;
+        can-focus: false;
       }
 
       styles [

--- a/src/app/components/search/search.blp
+++ b/src/app/components/search/search.blp
@@ -14,6 +14,8 @@ template $SearchResultsWidget : Box {
       valign: center;
       icon-name: "go-previous-symbolic";
       has-frame: false;
+      focus-on-click: false;
+      can-focus: false;
     }
 
     [title]

--- a/src/window.blp
+++ b/src/window.blp
@@ -64,6 +64,8 @@ Adw.ApplicationWindow window {
 
             Button search_button {
               icon-name: "system-search-symbolic";
+              focus-on-click: false;
+              can-focus: false;
             }
 
             [title]
@@ -74,6 +76,8 @@ Adw.ApplicationWindow window {
             [end]
             MenuButton user {
               icon-name: "open-menu-symbolic";
+              focus-on-click: false;
+              can-focus: false;
             }
           }
 


### PR DESCRIPTION
## Summary

Header buttons stayed visually highlighted ("sticky") after interaction or when visiting a page for the first time. This affected the back, search, and menu across the header bars. The change was also applied to some of the  WIP feature buttons.

## Problem

In GTK4, clicking a button or navigating between pages causes the button to receive focus, which applies a visible highlight that persists until the user clicks another focusable widget. For the MenuButton specifically,
dismissing the dropdown by clicking empty space returned focus to the button, keeping it highlighted indefinitely.

## Fix

Added `focus-on-click: false` and `can-focus: false` to all header bar buttons. This prevents focus from being granted on click, on popover close, and during page transitions.

## Testing

- [x] Open app → search button is not focused on startup
- [x] Click menu button → close by clicking away → no sticky highlight
- [x] Navigate into a playlist → back button is not highlighted
- [x] Click back/search/selection buttons → highlight clears after click