### PR TITLE
Retry batch_loader requests on InvalidToken

### DIFF
--- a/src/app/batch_loader.rs
+++ b/src/app/batch_loader.rs
@@ -93,6 +93,22 @@ impl BatchLoader {
             Ok(batch) => Some(create_action(query.source, batch)),
             // No token? Why was the batch loader called? Ah, whatever
             Err(SpotifyApiError::NoToken) => None,
+            Err(SpotifyApiError::InvalidToken) => {
+                // Retry once, token may have been refreshed in the meantime
+                let retry = match &query.source {
+                    SongsSource::Playlist(id) => {
+                        api.get_playlist_tracks(id, offset, batch_size).await
+                    }
+                    SongsSource::SavedTracks => api.get_saved_tracks(offset, batch_size).await,
+                    SongsSource::Album(id) => {
+                        api.get_album_tracks(id, offset, batch_size).await
+                    }
+                };
+                match retry {
+                    Ok(batch) => Some(create_action(query.source, batch)),
+                    _ => None,
+                }
+            }
             Err(err) => {
                 error!("Spotify API error: {}", err);
                 Some(AppAction::ShowNotification(gettext(


### PR DESCRIPTION
### Problem

There is a race condition between token refresh and data loading on startup, which causes an exception to be throw to the user when loading user data.

When `AppEvent::Started` fires, two things happen simultaneously:
1. The login component dispatches `TryLogin(Restore)` which triggers async token refresh via `Command::Restore` → `get_valid_token()` → `refresh_token()`
2. Components (saved_tracks, library, saved_playlists, user_menu) immediately start loading data

The batch_loader reads the expired cached token via `get_cached_blocking()` and makes API calls that return HTTP 401 (Unauthorized).

### Fix

Add an `InvalidToken` retry branch to `BatchLoader::query`, matching the existing pattern in `call_spotify_and_dispatch_many`. On the first `InvalidToken`, the request is retried once (by which time the token refresh has typically completed). If the retry also fails, it silently returns `None` rather than showing an error notification.

### Testing

Reproduced the error by forcing the token to expire and launching the application. After applying the fix the application launched without any issues logged into journctl. Multiple attempts were made to reproduce the race condition. 