### PR TITLE
Reorganize sidebar and rename entries

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -48,7 +48,7 @@ msgstr "An error occured. Check logs for details!"
 #: src/app/components/navigation/factory.rs:33
 #: src/app/components/sidebar/sidebar_item.rs:39
 msgid "Library"
-msgstr "Library"
+msgstr "Albums"
 
 #. translators: This is a sidebar entry to browse to saved playlists.
 #: src/app/components/navigation/factory.rs:54
@@ -59,7 +59,7 @@ msgstr "Playlists"
 #. This is the visible name for the play queue. It appears in the sidebar as well.
 #: src/app/components/sidebar/sidebar_item.rs:43
 msgid "Now playing"
-msgstr "Now playing"
+msgstr "Now Playing"
 
 #. translators: Short text displayed instead of a song title when nothing plays
 #. Short text displayed instead of a song title when nothing plays
@@ -120,7 +120,7 @@ msgstr "Artists"
 #: src/app/components/navigation/factory.rs:76
 #: src/app/components/sidebar/sidebar_item.rs:41
 msgid "Saved tracks"
-msgstr "Saved Tracks"
+msgstr "Tracks"
 
 #: src/app/components/playback/playback_controls.rs:64
 msgid "Pause"

--- a/src/app/components/sidebar/sidebar.rs
+++ b/src/app/components/sidebar/sidebar.rs
@@ -100,6 +100,9 @@ impl Sidebar {
 
         list_store.append(&SidebarItem::from_destination(SidebarDestination::Library));
         list_store.append(&SidebarItem::from_destination(
+            SidebarDestination::SavedPlaylists,
+        ));
+        list_store.append(&SidebarItem::from_destination(
             SidebarDestination::SavedTracks,
         ));
         list_store.append(&SidebarItem::from_destination(
@@ -107,9 +110,6 @@ impl Sidebar {
         ));
         list_store.append(&SidebarItem::playlists_section());
         list_store.append(&SidebarItem::create_playlist_item());
-        list_store.append(&SidebarItem::from_destination(
-            SidebarDestination::SavedPlaylists,
-        ));
 
         listbox.bind_model(
             Some(&list_store),


### PR DESCRIPTION
## Changes

- Moved the Playlists button out of the "All Playlists" section into the main navigation group alongside Library, Saved Tracks, and Now Playing.
- Renamed sidebar entries in the English locale:
  - "Library" → "Albums"
  - "Saved Tracks" → "Tracks"
  - "Now playing" → "Now Playing" (capitalization fix)

## Photo
<img width="285" height="260" alt="Screenshot From 2026-05-04 03-49-04" src="https://github.com/user-attachments/assets/9d20b220-6269-49f7-8825-8ca820425c99" />
