### PR TITLE
Show notification when Spotify rate limits requests

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -403,3 +403,8 @@ msgstr ""
 msgid "Refresh devices"
 msgstr ""
 
+
+#. translators: This notification is shown when Spotify throttles requests.
+#: src/app/components/mod.rs src/app/batch_loader.rs src/connect/player.rs
+msgid "Rate limited by Spotify. Please wait a moment and try again."
+msgstr ""

--- a/src/app/batch_loader.rs
+++ b/src/app/batch_loader.rs
@@ -109,6 +109,13 @@ impl BatchLoader {
                     _ => None,
                 }
             }
+            Err(SpotifyApiError::TooManyRequests) => {
+                error!("Spotify API error: rate limited");
+                Some(AppAction::ShowNotification(gettext(
+                    // translators: This notification is shown when Spotify throttles requests.
+                    "Rate limited by Spotify. Please wait a moment and try again.",
+                )))
+            }
             Err(err) => {
                 error!("Spotify API error: {}", err);
                 Some(AppAction::ShowNotification(gettext(

--- a/src/app/components/mod.rs
+++ b/src/app/components/mod.rs
@@ -122,6 +122,13 @@ impl dyn ActionDispatcher {
                 Ok(actions) => actions,
                 Err(SpotifyApiError::NoToken) => vec![],
                 Err(SpotifyApiError::InvalidToken) => call().await.unwrap_or_else(|_| Vec::new()),
+                Err(SpotifyApiError::TooManyRequests) => {
+                    error!("Spotify API error: rate limited");
+                    vec![AppAction::ShowNotification(gettext(
+                        // translators: This notification is shown when Spotify throttles requests.
+                        "Rate limited by Spotify. Please wait a moment and try again.",
+                    ))]
+                }
                 Err(err) => {
                     error!("Spotify API error: {}", err);
                     vec![AppAction::ShowNotification(gettext(

--- a/src/connect/player.rs
+++ b/src/connect/player.rs
@@ -241,6 +241,12 @@ impl ConnectPlayer {
                 let device_id = self.device_id.read().ok()?.clone();
                 if let Some(device_id) = device_id {
                     let result = self.handle_other_command(device_id, command).await;
+                    if matches!(result, Err(SpotifyApiError::TooManyRequests)) {
+                        self.send_actions([AppAction::ShowNotification(gettext(
+                            // translators: This notification is shown when Spotify throttles requests.
+                            "Rate limited by Spotify. Please wait a moment and try again.",
+                        ))]);
+                    }
                     matches!(result, Err(SpotifyApiError::BadStatus(404, _)))
                 } else {
                     true


### PR DESCRIPTION
## Summary

Surface a user-facing notification when Spotify returns 429 (Too Many Requests) instead of showing the generic "An error occurred" message.

## Motivation

Users have reported they were being rate limited by Spotify, but the app gave no indication if this was the case.

This change makes the app transparent about what's happening: if Spotify is blocking requests, the user knows it's not our fault and that they should wait before retrying.

## Changes

- `src/app/components/mod.rs` - Handle `TooManyRequests` in the general API
  dispatch (covers search, browsing, library operations)
- `src/app/batch_loader.rs` - Handle `TooManyRequests` in paginated track loading
- `src/connect/player.rs` - Handle `TooManyRequests` in playback commands
- `po/en.po` - Add translatable notification string

## Testing

- Builds cleanly with `cargo check`
- I was unable to get spotify to return a 429 response during testing.