### PR TITLE
Update snapshot workflow to use runtime 50 just like app

### DIFF
--- a/.github/workflows/riff-snapshots.yml
+++ b/.github/workflows/riff-snapshots.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Flatpak ${{ matrix.variant.arch }}"
     runs-on: ${{ matrix.variant.runner }}
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
       options: --privileged
     strategy:
       matrix:


### PR DESCRIPTION
Proposing we upgrade the runtime version used in the snapshots GitHub workflow from 48 to 50 to match the app.

https://github.com/Diegovsky/riff/blob/d54ea91c59d74b7feb9b1fd95a7f26176eb0408e/dev.diegovsky.Riff.snapshots.json#L4