### PR TITLE
Sync `meson.build` and `Cargo.toml` version with `metainfo.xml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riff"
-version = "0.5.0"
+version = "26.03"
 edition = "2018"
 license = "MIT"
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
   'riff',
-  version: '25.03',
+  version: '26.03',
   meson_version: '>= 0.59.0',
   default_options: ['warning_level=2', 'buildtype=release'],
 )


### PR DESCRIPTION
Proposing we update versions in `meson.build` and `Cargo.toml` to `26.03` to match `metainfo.xml`.

https://github.com/Diegovsky/riff/blob/d54ea91c59d74b7feb9b1fd95a7f26176eb0408e/data/dev.diegovsky.Riff.metainfo.xml#L60-L74