### PR TITLE
Fixed leading zero issue with cargo version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "riff"
-version = "0.5.0"
+version = "26.3.0"
 dependencies = [
  "anyhow",
  "env_logger 0.10.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riff"
-version = "26.03"
+version = "26.3.0"
 edition = "2018"
 license = "MIT"
 


### PR DESCRIPTION
## Summary
Fixes the Cargo.toml version that was set to 26.03 in #93, which is invalid for Cargo as semver does not allow leading zeros in version components.
  