### PR TITLE
Fix duplicate page loads by eagerly consuming pagination offsets in state

### DIFF
--- a/src/app/batch_loader.rs
+++ b/src/app/batch_loader.rs
@@ -53,17 +53,6 @@ pub struct BatchQuery {
     pub batch: Batch,
 }
 
-impl BatchQuery {
-    // Given a query, compute the next batch to get (if any)
-    pub fn next(&self) -> Option<Self> {
-        let Self { source, batch } = self;
-        Some(Self {
-            source: source.clone(),
-            batch: batch.next()?,
-        })
-    }
-}
-
 impl BatchLoader {
     pub fn new(api: Arc<dyn SpotifyApiClient + Send + Sync>) -> Self {
         Self { api }

--- a/src/app/components/artist_details/artist_details_model.rs
+++ b/src/app/components/artist_details/artist_details_model.rs
@@ -9,7 +9,7 @@ use crate::app::components::{labels, PlaylistModel};
 use crate::app::models::*;
 use crate::app::state::SelectionContext;
 use crate::app::state::{
-    BrowserAction, BrowserEvent, PlaybackAction, SelectionAction, SelectionState,
+    BrowserAction, BrowserEvent, PlaybackAction, PaginationTarget, SelectionAction, SelectionState,
 };
 use crate::app::{ActionDispatcher, AppAction, AppEvent, AppModel, ListStore};
 
@@ -61,11 +61,15 @@ impl ArtistDetailsModel {
     pub fn load_more(&self) -> Option<()> {
         let api = self.app_model.get_spotify();
         let state = self.app_model.get_state();
-        let next_page = &state.browser.artist_state(&self.id)?.next_page;
+        let next_page = state.browser.artist_state(&self.id)?.next_page.clone();
+        drop(state);
 
-        let id = next_page.data.clone();
+        let id = next_page.data;
         let batch_size = next_page.batch_size;
         let offset = next_page.next_offset?;
+
+        self.app_model
+            .update_state(BrowserAction::ConsumeNextPage(PaginationTarget::ArtistReleases(id.clone())).into());
 
         self.dispatcher
             .call_spotify_and_dispatch(move || async move {

--- a/src/app/components/details/details_model.rs
+++ b/src/app/components/details/details_model.rs
@@ -15,7 +15,7 @@ use crate::app::dispatch::ActionDispatcher;
 use crate::app::models::*;
 use crate::app::state::SelectionContext;
 use crate::app::state::{BrowserAction, PlaybackAction, SelectionAction, SelectionState};
-use crate::app::{AppAction, AppEvent, AppModel, AppState, BatchQuery, SongsSource};
+use crate::app::{AppAction, AppEvent, AppModel, AppState, PaginationTarget, SongsSource};
 use crate::feature_flags::{self, FeatureFlag};
 
 pub struct DetailsModel {
@@ -143,23 +143,25 @@ impl DetailsModel {
     }
 
     pub fn load_more(&self) -> Option<()> {
-        let last_batch = self.song_list_model().last_batch()?;
-        let query = BatchQuery {
-            source: SongsSource::Album(self.id.clone()),
-            batch: last_batch,
-        };
+        let api = self.app_model.get_spotify();
 
+        let state = self.app_model.get_state();
+        let next_page = state.browser.details_state(&self.id)?.next_tracks_page.clone();
+        drop(state);
+
+        let batch_size = next_page.batch_size;
+        let offset = next_page.next_offset?;
         let id = self.id.clone();
-        let next_query = query.next()?;
-        let loader = self.app_model.get_batch_loader();
 
-        self.dispatcher.dispatch_async(Box::pin(async move {
-            loader
-                .query(next_query, |_s, song_batch| {
-                    BrowserAction::AppendAlbumTracks(id, Box::new(song_batch)).into()
-                })
-                .await
-        }));
+        self.app_model
+            .update_state(BrowserAction::ConsumeNextPage(PaginationTarget::AlbumTracks(id.clone())).into());
+
+        self.dispatcher
+            .call_spotify_and_dispatch(move || async move {
+                api.get_album_tracks(&id, offset, batch_size)
+                    .await
+                    .map(|song_batch| BrowserAction::AppendAlbumTracks(id, Box::new(song_batch)).into())
+            });
 
         Some(())
     }

--- a/src/app/components/library/library_model.rs
+++ b/src/app/components/library/library_model.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use crate::app::models::*;
 use crate::app::state::HomeState;
-use crate::app::{ActionDispatcher, AppAction, AppModel, BrowserAction, ListStore};
+use crate::app::{ActionDispatcher, AppAction, AppModel, BrowserAction, ListStore, PaginationTarget};
 
 pub struct LibraryModel {
     app_model: Rc<AppModel>,
@@ -50,9 +50,13 @@ impl LibraryModel {
     pub fn load_more_albums(&self) -> Option<()> {
         let api = self.app_model.get_spotify();
 
-        let next_page = &self.state()?.next_albums_page;
-        let batch_size = next_page.batch_size;
-        let offset = next_page.next_offset?;
+        let state = self.state()?;
+        let batch_size = state.next_albums_page.batch_size;
+        let offset = state.next_albums_page.next_offset?;
+        drop(state);
+
+        self.app_model
+            .update_state(BrowserAction::ConsumeNextPage(PaginationTarget::SavedAlbums).into());
 
         self.dispatcher
             .call_spotify_and_dispatch(move || async move {

--- a/src/app/components/playlist_details/playlist_details_model.rs
+++ b/src/app/components/playlist_details/playlist_details_model.rs
@@ -11,7 +11,7 @@ use crate::app::models::*;
 use crate::app::state::SelectionContext;
 use crate::app::state::{BrowserAction, PlaybackAction, SelectionAction, SelectionState};
 use crate::app::AppState;
-use crate::app::{ActionDispatcher, AppAction, AppModel, BatchQuery, SongsSource};
+use crate::app::{ActionDispatcher, AppAction, AppModel, PaginationTarget, SongsSource};
 use crate::feature_flags::{self, FeatureFlag};
 
 pub struct PlaylistDetailsModel {
@@ -111,24 +111,25 @@ impl PlaylistDetailsModel {
     }
 
     pub fn load_more_tracks(&self) -> Option<()> {
-        let last_batch = self.song_list_model().last_batch()?;
-        let query = BatchQuery {
-            source: SongsSource::Playlist(self.id.clone()),
-            batch: last_batch,
-        };
+        let api = self.app_model.get_spotify();
 
+        let state = self.app_model.get_state();
+        let next_page = state.browser.playlist_details_state(&self.id)?.next_tracks_page.clone();
+        drop(state);
+
+        let batch_size = next_page.batch_size;
+        let offset = next_page.next_offset?;
         let id = self.id.clone();
-        let next_query = query.next()?;
-        debug!("next_query = {:?}", &next_query);
-        let loader = self.app_model.get_batch_loader();
 
-        self.dispatcher.dispatch_async(Box::pin(async move {
-            loader
-                .query(next_query, |_s, song_batch| {
-                    BrowserAction::AppendPlaylistTracks(id, Box::new(song_batch)).into()
-                })
-                .await
-        }));
+        self.app_model
+            .update_state(BrowserAction::ConsumeNextPage(PaginationTarget::PlaylistTracks(id.clone())).into());
+
+        self.dispatcher
+            .call_spotify_and_dispatch(move || async move {
+                api.get_playlist_tracks(&id, offset, batch_size)
+                    .await
+                    .map(|song_batch| BrowserAction::AppendPlaylistTracks(id, Box::new(song_batch)).into())
+            });
 
         Some(())
     }

--- a/src/app/components/saved_playlists/saved_playlists_model.rs
+++ b/src/app/components/saved_playlists/saved_playlists_model.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use crate::app::models::*;
 use crate::app::state::HomeState;
-use crate::app::{ActionDispatcher, AppAction, AppModel, BrowserAction, ListStore};
+use crate::app::{ActionDispatcher, AppAction, AppModel, BrowserAction, ListStore, PaginationTarget};
 
 pub struct SavedPlaylistsModel {
     app_model: Rc<AppModel>,
@@ -50,9 +50,13 @@ impl SavedPlaylistsModel {
     pub fn load_more_playlists(&self) -> Option<()> {
         let api = self.app_model.get_spotify();
 
-        let next_page = &self.state()?.next_playlists_page;
-        let batch_size = next_page.batch_size;
-        let offset = next_page.next_offset?;
+        let state = self.state()?;
+        let batch_size = state.next_playlists_page.batch_size;
+        let offset = state.next_playlists_page.next_offset?;
+        drop(state);
+
+        self.app_model
+            .update_state(BrowserAction::ConsumeNextPage(PaginationTarget::SavedPlaylists).into());
 
         self.dispatcher
             .call_spotify_and_dispatch(move || async move {

--- a/src/app/components/saved_tracks/saved_tracks_model.rs
+++ b/src/app/components/saved_tracks/saved_tracks_model.rs
@@ -7,7 +7,7 @@ use crate::app::components::{labels, PlaylistModel};
 use crate::app::models::*;
 use crate::app::state::SelectionContext;
 use crate::app::state::{PlaybackAction, SelectionAction, SelectionState};
-use crate::app::{ActionDispatcher, AppAction, AppModel, BatchQuery, BrowserAction, SongsSource};
+use crate::app::{ActionDispatcher, AppAction, AppModel, BatchQuery, BrowserAction, PaginationTarget, SongsSource};
 
 pub struct SavedTracksModel {
     app_model: Rc<AppModel>,
@@ -38,19 +38,25 @@ impl SavedTracksModel {
     }
 
     pub fn load_more(&self) -> Option<()> {
-        let loader = self.app_model.get_batch_loader();
-        let last_batch = self.song_list_model().last_batch()?.next()?;
-        let query = BatchQuery {
-            source: SongsSource::SavedTracks,
-            batch: last_batch,
-        };
-        self.dispatcher.dispatch_async(Box::pin(async move {
-            loader
-                .query(query, |_s, song_batch| {
-                    BrowserAction::AppendSavedTracks(Box::new(song_batch)).into()
-                })
-                .await
-        }));
+        let api = self.app_model.get_spotify();
+
+        let state = self.app_model.get_state();
+        let next_page = state.browser.home_state()?.next_saved_tracks_page.clone();
+        drop(state);
+
+        let batch_size = next_page.batch_size;
+        let offset = next_page.next_offset?;
+
+        self.app_model
+            .update_state(BrowserAction::ConsumeNextPage(PaginationTarget::SavedTracks).into());
+
+        self.dispatcher
+            .call_spotify_and_dispatch(move || async move {
+                api.get_saved_tracks(offset, batch_size)
+                    .await
+                    .map(|song_batch| BrowserAction::AppendSavedTracks(Box::new(song_batch)).into())
+            });
+
         Some(())
     }
 }

--- a/src/app/components/user_details/user_details_model.rs
+++ b/src/app/components/user_details/user_details_model.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use crate::app::models::*;
 use crate::app::state::BrowserAction;
-use crate::app::{ActionDispatcher, AppAction, AppModel, ListStore};
+use crate::app::{ActionDispatcher, AppAction, AppModel, ListStore, PaginationTarget};
 
 pub struct UserDetailsModel {
     pub id: String,
@@ -45,12 +45,18 @@ impl UserDetailsModel {
 
     pub fn load_more(&self) -> Option<()> {
         let api = self.app_model.get_spotify();
-        let state = self.app_model.get_state();
-        let next_page = &state.browser.user_state(&self.id)?.next_page;
 
-        let id = next_page.data.clone();
+        let state = self.app_model.get_state();
+        let next_page = state.browser.user_state(&self.id)?.next_page.clone();
+        drop(state);
+
+        let id = next_page.data;
         let batch_size = next_page.batch_size;
         let offset = next_page.next_offset?;
+
+        self.app_model
+            .update_state(BrowserAction::ConsumeNextPage(PaginationTarget::UserPlaylists(id.clone())).into());
+
         self.dispatcher
             .call_spotify_and_dispatch(move || async move {
                 api.get_user_playlists(&id, offset, batch_size)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -16,7 +16,7 @@ mod list_store;
 pub use list_store::*;
 
 pub mod state;
-pub use state::{AppAction, AppEvent, AppModel, AppState, BrowserAction, BrowserEvent};
+pub use state::{AppAction, AppEvent, AppModel, AppState, BrowserAction, BrowserEvent, PaginationTarget};
 
 mod batch_loader;
 pub use batch_loader::*;

--- a/src/app/models/songs/support.rs
+++ b/src/app/models/songs/support.rs
@@ -314,11 +314,6 @@ impl SongList {
 
         let index = batch.offset / batch.batch_size;
 
-        if self.batches.contains_key(&index) {
-            debug!("batch already loaded");
-            return None;
-        }
-
         let insertion_start = self.estimated_len(index);
         let len = songs.len();
         let ids = songs
@@ -588,10 +583,6 @@ mod tests {
 
         let range = list.add(batch(2));
         assert_eq!(range, Some(ListRangeUpdate::inserted(4, 2)));
-        assert_eq!(list.partial_len(), 8);
-
-        let range = list.add(batch(2));
-        assert_eq!(range, None);
         assert_eq!(list.partial_len(), 8);
     }
 

--- a/src/app/state/browser_state.rs
+++ b/src/app/state/browser_state.rs
@@ -6,6 +6,17 @@ use crate::app::models::*;
 use std::borrow::Cow;
 use std::iter::Iterator;
 
+#[derive(Clone, Debug)]
+pub enum PaginationTarget {
+    SavedAlbums,
+    SavedPlaylists,
+    SavedTracks,
+    ArtistReleases(String),
+    UserPlaylists(String),
+    PlaylistTracks(String),
+    AlbumTracks(String),
+}
+
 // Actions that affect any "screen" that we push over time
 #[derive(Clone, Debug)]
 pub enum BrowserAction {
@@ -38,6 +49,7 @@ pub enum BrowserAction {
     AppendSavedTracks(Box<SongBatch>),
     SaveTracks(Vec<SongDescription>),
     RemoveSavedTracks(Vec<String>),
+    ConsumeNextPage(PaginationTarget),
 }
 
 impl From<BrowserAction> for AppAction {

--- a/src/app/state/pagination.rs
+++ b/src/app/state/pagination.rs
@@ -33,10 +33,19 @@ where
         }
     }
 
+    // Eagerly advance the offset before the request completes.
+    // Returns the offset to use for the request, or None if already consumed/exhausted.
+    pub fn next_offset_take(&mut self) -> Option<usize> {
+        let offset = self.next_offset.take()?;
+        // Optimistically assume a full batch will be returned
+        self.next_offset = Some(offset + self.batch_size);
+        Some(offset)
+    }
+
     pub fn set_loaded_count(&mut self, loaded_count: usize) {
         if let Some(offset) = self.next_offset.take() {
             self.next_offset = if loaded_count >= self.batch_size {
-                Some(offset + self.batch_size)
+                Some(offset)
             } else {
                 None
             }

--- a/src/app/state/screen_states.rs
+++ b/src/app/state/screen_states.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::cmp::PartialEq;
 
-use super::{pagination::Pagination, BrowserAction, BrowserEvent, UpdatableState};
+use super::{pagination::Pagination, BrowserAction, BrowserEvent, PaginationTarget, UpdatableState};
 use crate::app::models::*;
 use crate::app::ListStore;
 
@@ -43,15 +43,17 @@ pub struct DetailsState {
     pub content: Option<AlbumFullDescription>,
     // Read the songs from here, not content (won't get more than the initial batch of songs)
     pub songs: SongListModel,
+    pub next_tracks_page: Pagination<String>,
 }
 
 impl DetailsState {
     pub fn new(id: String) -> Self {
         Self {
             id: id.clone(),
-            name: ScreenName::AlbumDetails(id),
+            name: ScreenName::AlbumDetails(id.clone()),
             content: None,
             songs: SongListModel::new(50),
+            next_tracks_page: Pagination::new(id, 50),
         }
     }
 }
@@ -65,12 +67,20 @@ impl UpdatableState for DetailsState {
             BrowserAction::SetAlbumDetails(album) if album.description.id == self.id => {
                 let AlbumDescription { id, songs, .. } = album.description.clone();
                 self.songs.add(songs).commit();
+                self.next_tracks_page.reset_count(self.songs.partial_len());
                 self.content = Some(*album.clone());
                 vec![BrowserEvent::AlbumDetailsLoaded(id)]
             }
             BrowserAction::AppendAlbumTracks(id, batch) if id == &self.id => {
+                self.next_tracks_page.set_loaded_count(batch.songs.len());
                 self.songs.add(*batch.clone()).commit();
                 vec![BrowserEvent::AlbumTracksAppended(id.clone())]
+            }
+            BrowserAction::ConsumeNextPage(PaginationTarget::AlbumTracks(id))
+                if id == &self.id =>
+            {
+                self.next_tracks_page.next_offset_take();
+                vec![]
             }
             BrowserAction::SaveAlbum(album) if album.id == self.id => {
                 let id = album.id.clone();
@@ -100,15 +110,17 @@ pub struct PlaylistDetailsState {
     pub playlist: Option<PlaylistDescription>,
     // Read the songs from here, not content (won't get more than the initial batch of songs)
     pub songs: SongListModel,
+    pub next_tracks_page: Pagination<String>,
 }
 
 impl PlaylistDetailsState {
     pub fn new(id: String) -> Self {
         Self {
             id: id.clone(),
-            name: ScreenName::PlaylistDetails(id),
+            name: ScreenName::PlaylistDetails(id.clone()),
             playlist: None,
             songs: SongListModel::new(100),
+            next_tracks_page: Pagination::new(id, 100),
         }
     }
 }
@@ -122,6 +134,7 @@ impl UpdatableState for PlaylistDetailsState {
             BrowserAction::SetPlaylistDetails(playlist, song_batch) if playlist.id == self.id => {
                 let PlaylistDescription { id, .. } = *playlist.clone();
                 self.songs.add(*song_batch.clone()).commit();
+                self.next_tracks_page.reset_count(self.songs.partial_len());
                 self.playlist = Some(*playlist.clone());
                 vec![BrowserEvent::PlaylistDetailsLoaded(id)]
             }
@@ -132,8 +145,15 @@ impl UpdatableState for PlaylistDetailsState {
                 vec![BrowserEvent::PlaylistDetailsLoaded(self.id.clone())]
             }
             BrowserAction::AppendPlaylistTracks(id, song_batch) if id == &self.id => {
+                self.next_tracks_page.set_loaded_count(song_batch.songs.len());
                 self.songs.add(*song_batch.clone()).commit();
                 vec![BrowserEvent::PlaylistTracksAppended(id.clone())]
+            }
+            BrowserAction::ConsumeNextPage(PaginationTarget::PlaylistTracks(id))
+                if id == &self.id =>
+            {
+                self.next_tracks_page.next_offset_take();
+                vec![]
             }
             BrowserAction::RemoveTracksFromPlaylist(id, uris) if id == &self.id => {
                 self.songs.remove(&uris[..]).commit();
@@ -194,6 +214,12 @@ impl UpdatableState for ArtistState {
                 self.albums.extend(albums.iter().map(|a| a.into()));
                 vec![BrowserEvent::ArtistDetailsUpdated(self.id.clone())]
             }
+            BrowserAction::ConsumeNextPage(PaginationTarget::ArtistReleases(id))
+                if id == &self.id =>
+            {
+                self.next_page.next_offset_take();
+                vec![]
+            }
             _ => vec![],
         }
     }
@@ -207,6 +233,7 @@ pub struct HomeState {
     pub albums: ListStore<AlbumModel>,
     pub next_playlists_page: Pagination<()>,
     pub playlists: ListStore<AlbumModel>,
+    pub next_saved_tracks_page: Pagination<()>,
     pub saved_tracks: SongListModel,
 }
 
@@ -219,6 +246,7 @@ impl Default for HomeState {
             albums: ListStore::new(),
             next_playlists_page: Pagination::new((), 30),
             playlists: ListStore::new(),
+            next_saved_tracks_page: Pagination::new((), 50),
             saved_tracks: SongListModel::new(50),
         }
     }
@@ -304,6 +332,7 @@ impl UpdatableState for HomeState {
                 }
             }
             BrowserAction::AppendSavedTracks(song_batch) => {
+                self.next_saved_tracks_page.set_loaded_count(song_batch.songs.len());
                 if self.saved_tracks.add(*song_batch.clone()).commit() {
                     vec![BrowserEvent::SavedTracksUpdated]
                 } else {
@@ -312,12 +341,14 @@ impl UpdatableState for HomeState {
             }
             BrowserAction::SetSavedTracks(song_batch) => {
                 let song_batch = *song_batch.clone();
+                let len = song_batch.songs.len();
                 if self
                     .saved_tracks
                     .clear()
                     .and(|s| s.add(song_batch))
                     .commit()
                 {
+                    self.next_saved_tracks_page.reset_count(len);
                     vec![BrowserEvent::SavedTracksUpdated]
                 } else {
                     vec![]
@@ -330,6 +361,18 @@ impl UpdatableState for HomeState {
             BrowserAction::RemoveSavedTracks(tracks) => {
                 self.saved_tracks.remove(&tracks[..]).commit();
                 vec![BrowserEvent::SavedTracksUpdated]
+            }
+            BrowserAction::ConsumeNextPage(PaginationTarget::SavedAlbums) => {
+                self.next_albums_page.next_offset_take();
+                vec![]
+            }
+            BrowserAction::ConsumeNextPage(PaginationTarget::SavedPlaylists) => {
+                self.next_playlists_page.next_offset_take();
+                vec![]
+            }
+            BrowserAction::ConsumeNextPage(PaginationTarget::SavedTracks) => {
+                self.next_saved_tracks_page.next_offset_take();
+                vec![]
             }
             _ => vec![],
         }
@@ -418,6 +461,12 @@ impl UpdatableState for UserState {
                 self.next_page.set_loaded_count(playlists.len());
                 self.playlists.extend(playlists.iter().map(|p| p.into()));
                 vec![BrowserEvent::UserDetailsUpdated(self.id.clone())]
+            }
+            BrowserAction::ConsumeNextPage(PaginationTarget::UserPlaylists(id))
+                if id == &self.id =>
+            {
+                self.next_page.next_offset_take();
+                vec![]
             }
             _ => vec![],
         }


### PR DESCRIPTION
## Summary
  
Fixes a race condition where rapid scrolling could trigger multiple requests for the same page offset, resulting in duplicate data being appended.
  
## Problem
  
The previous approach derived the "next page" from the last batch stored in `SongList`. However, as the offset wasn't consumed until the response arrived, multiple `load_more` calls fired before the first response could all read the same offset and dispatch redundant requests.
  
## Solution
  
Move pagination tracking into the reducer state (`DetailsState`,  `PlaylistDetailsState`, `HomeState`, `ArtistState`, `UserState`) and introduce a `ConsumeNextPage` action that eagerly advances the offset *before* the async API call completes. This guarantees each offset is only requested once.
  
Key changes:
- New `PaginationTarget` enum identifies which resource is being paginated
- New `BrowserAction::ConsumeNextPage` dispatched synchronously before the API call
- `Pagination::next_offset_take()` optimistically advances the offset
- `set_loaded_count()` now corrects the offset if fewer items than a full batch were returned (end of list)
- Removed `BatchQuery::next()` and the duplicate-batch guard in `SongList::add()` since the state now prevents duplicates
  
## Testing
- Verified rapid scrolling no longer produces duplicate entries
- Verified pagination stops correctly at end of list