### PR TITLE
Add setup-dev.sh script for installing build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Originally a fork of [Spot](https://github.com/xou816/spot),  Riff continues dev
 
 If you have any feature suggestions or want to contribute to the project, feel free to leave an issue / pull request or join the discussion on our [Discord server](https://discord.gg/SYuYsjzWbm)!
 
-*Note*: AI contributions in any part are not welcome. 
+*Note*: AI contributions in any part are not welcome.
 
 ## Installing
 
@@ -70,6 +70,14 @@ If you feel like it, you are welcome to open a PR to be added to the `TRANSLATOR
 
 ## Building
 
+### Dependencies
+
+You can install the required development dependencies by running:
+
+```
+./setup-dev.sh
+```
+
 ### With GNOME Builder and flatpak
 
 Pre-requisite: install the `org.freedesktop.Sdk.Extension.rust-stable` SDK extension with flatpak. Builder might do this for you automatically, but it will install an older version; make sure  the version installed matches the version of the Freedesktop SDK GNOME uses.
@@ -78,9 +86,7 @@ Open the project in GNOME Builder and make the `dev.diegovsky.Riff.development.j
 
 ### Manually
 
-Requires Rust (stable), **GTK4**, and a couple other things. Also requires **libadwaita** and **blueprint-compiler**: they are not packaged on all distros at the moment, you might have to build them yourself!
-
-With meson:
+You build and install with meson:
 
 ```
 meson setup target -Dbuildtype=debug -Doffline=false --prefix="$HOME/.local"

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Dev setup script for Riff - installs build dependencies.
+# Detects the system package manager and prompts before installing.
+
+confirm_risks() {
+    echo ""
+    echo "WARNING!"
+    echo "This script is a best effort attempt to setup the required packages for building Riff on your system."
+    echo "As follows this script might fail or break dependencies on your system."
+    echo "If you are unconformable or do not understand the risks with installing packages, do not proceed."
+    echo ""
+
+    read -r -p "Proceed? [y/N] " response
+    [[ "$response" =~ ^[Yy]$ ]]
+}
+
+confirm_install() {
+    read -r -p "Install the above packages? [y/N] " response
+    [[ "$response" =~ ^[Yy]$ ]]
+}
+
+detect_pkg_manager() {
+    for cmd in dnf yum apt-get pacman zypper; do
+        if command -v "$cmd" &>/dev/null; then
+            echo "$cmd"
+            return
+        fi
+    done
+    echo ""
+}
+
+if ! confirm_risks; then
+    echo "Aborted."
+    exit 0
+fi
+echo ""
+
+PKG_MANAGER=$(detect_pkg_manager)
+
+if [[ -z "$PKG_MANAGER" ]]; then
+    echo "Error: No supported package manager found (dnf, yum, apt-get, pacman, zypper)."
+    exit 1
+fi
+
+echo "Detected package manager: $PKG_MANAGER"
+
+NEED_RUSTUP=0
+
+case "$PKG_MANAGER" in
+    dnf|yum)
+        PACKAGES=(
+            meson
+            ninja-build
+            cargo
+            rust
+            pkgconf-pkg-config
+            gtk4-devel
+            libadwaita-devel
+            glib2-devel
+            openssl-devel
+            alsa-lib-devel
+            pulseaudio-libs-devel
+            gstreamer1-devel
+            gstreamer1-plugins-base-devel
+            gettext-devel
+            libcurl-devel
+            blueprint-compiler
+            libxml2
+        )
+        INSTALL_CMD="sudo $PKG_MANAGER install"
+        ;;
+    apt-get)
+        PACKAGES=(
+            meson
+            ninja-build
+            pkg-config
+            libgtk-4-dev
+            libadwaita-1-dev
+            libglib2.0-dev
+            libssl-dev
+            libasound2-dev
+            libpulse-dev
+            libgstreamer1.0-dev
+            libgstreamer-plugins-base1.0-dev
+            gettext
+            libcurl4-openssl-dev
+            blueprint-compiler
+            libxml2-utils
+        )
+        INSTALL_CMD="sudo apt-get install"
+        NEED_RUSTUP=1
+        ;;
+    pacman)
+        PACKAGES=(
+            meson
+            ninja
+            rust
+            pkgconf
+            gtk4
+            libadwaita
+            glib2
+            openssl
+            alsa-lib
+            libpulse
+            gstreamer
+            gst-plugins-base
+            gettext
+            curl
+            blueprint-compiler
+            libxml2
+        )
+        INSTALL_CMD="sudo pacman -S --needed"
+        ;;
+esac
+
+echo ""
+echo "The following packages will be installed:"
+printf '  %s\n' "${PACKAGES[@]}"
+echo ""
+
+if confirm_install; then
+    $INSTALL_CMD "${PACKAGES[@]}"
+
+    if [[ "$NEED_RUSTUP" -eq 1 ]]; then
+        echo ""
+        echo "Debian/Ubuntu ship a Rust toolchain that is too old for Riff's dependencies."
+        echo "Installing the latest stable Rust via rustup..."
+        if command -v rustup &>/dev/null; then
+            rustup update stable
+        else
+            echo "Couldn't find rustup. Aborting."
+            exit 1
+        fi
+        echo "Rust $(rustc --version) installed via rustup."
+    fi
+
+    echo ""
+    echo "Done! You can now build with:"
+    echo '  meson setup target -Dbuildtype=debug -Doffline=false --prefix="$HOME/.local"'
+    echo '  ninja install -C target'
+    echo 'You can run your local build with:'
+    echo '  ~/.local/bin/riff'
+else
+    echo "Aborted."
+fi


### PR DESCRIPTION
## Summary

Adds a `setup-dev.sh` script that automates installing the build dependencies for Riff. The script:
- Detects the system package manager (dnf/yum, apt-get, pacman)
- Lists packages and prompts for confirmation before installing
- Handles Rust toolchain setup via rustup on Debian/Ubuntu