### PR TITLE
Improved logout workflow

### DIFF
--- a/src/app/batch_loader.rs
+++ b/src/app/batch_loader.rs
@@ -72,32 +72,20 @@ impl BatchLoader {
         let Batch {
             offset, batch_size, ..
         } = query.batch;
-        let result = match &query.source {
-            SongsSource::Playlist(id) => api.get_playlist_tracks(id, offset, batch_size).await,
-            SongsSource::SavedTracks => api.get_saved_tracks(offset, batch_size).await,
-            SongsSource::Album(id) => api.get_album_tracks(id, offset, batch_size).await,
+        let do_fetch = || match &query.source {
+            SongsSource::Playlist(id) => api.get_playlist_tracks(id, offset, batch_size),
+            SongsSource::SavedTracks => api.get_saved_tracks(offset, batch_size),
+            SongsSource::Album(id) => api.get_album_tracks(id, offset, batch_size),
+        };
+
+        let result = match do_fetch().await {
+            Err(SpotifyApiError::InvalidToken) => do_fetch().await,
+            other => other,
         };
 
         match result {
             Ok(batch) => Some(create_action(query.source, batch)),
-            // No token? Why was the batch loader called? Ah, whatever
-            Err(SpotifyApiError::NoToken) => None,
-            Err(SpotifyApiError::InvalidToken) => {
-                // Retry once, token may have been refreshed in the meantime
-                let retry = match &query.source {
-                    SongsSource::Playlist(id) => {
-                        api.get_playlist_tracks(id, offset, batch_size).await
-                    }
-                    SongsSource::SavedTracks => api.get_saved_tracks(offset, batch_size).await,
-                    SongsSource::Album(id) => {
-                        api.get_album_tracks(id, offset, batch_size).await
-                    }
-                };
-                match retry {
-                    Ok(batch) => Some(create_action(query.source, batch)),
-                    _ => None,
-                }
-            }
+            Err(SpotifyApiError::NoToken | SpotifyApiError::InvalidToken) => None,
             Err(SpotifyApiError::TooManyRequests) => {
                 error!("Spotify API error: rate limited");
                 Some(AppAction::ShowNotification(gettext(

--- a/src/app/components/library/library.rs
+++ b/src/app/components/library/library.rs
@@ -145,7 +145,6 @@ impl EventListener for Library {
     fn on_event(&mut self, event: &AppEvent) {
         match event {
             AppEvent::Started => {
-                let _ = self.model.refresh_saved_albums();
                 self.bind_flowbox();
             }
             AppEvent::LoginEvent(LoginEvent::LoginCompleted) => {

--- a/src/app/components/login/login.rs
+++ b/src/app/components/login/login.rs
@@ -68,7 +68,7 @@ impl LoginWindow {
         let window = self.upcast_ref::<libadwaita::Window>();
         window.connect_close_request(move |_| {
             on_close();
-            glib::Propagation::Stop
+            glib::Propagation::Proceed
         });
     }
 
@@ -103,7 +103,7 @@ impl Login {
             #[weak]
             parent,
             move || {
-                if let Some(app) = parent.application().as_ref() {
+                if let Some(app) = parent.application() {
                     app.quit();
                 }
             }

--- a/src/app/components/saved_playlists/saved_playlists.rs
+++ b/src/app/components/saved_playlists/saved_playlists.rs
@@ -145,7 +145,6 @@ impl EventListener for SavedPlaylists {
     fn on_event(&mut self, event: &AppEvent) {
         match event {
             AppEvent::Started => {
-                let _ = self.model.refresh_saved_playlists();
                 self.bind_flowbox();
             }
             AppEvent::LoginEvent(LoginEvent::LoginCompleted) => {

--- a/src/app/components/saved_tracks/saved_tracks.rs
+++ b/src/app/components/saved_tracks/saved_tracks.rs
@@ -111,7 +111,7 @@ impl Component for SavedTracks {
 impl EventListener for SavedTracks {
     fn on_event(&mut self, event: &AppEvent) {
         match event {
-            AppEvent::Started | AppEvent::LoginEvent(LoginEvent::LoginCompleted) => {
+            AppEvent::LoginEvent(LoginEvent::LoginCompleted) => {
                 self.model.load_initial();
             }
             _ => {}

--- a/src/app/state/app_state.rs
+++ b/src/app/state/app_state.rs
@@ -260,6 +260,23 @@ impl AppState {
             AppAction::PlaybackAction(a) => forward_action(a, &mut self.playback),
             AppAction::BrowserAction(a) => forward_action(a, &mut self.browser),
             AppAction::SelectionAction(a) => forward_action(a, &mut self.selection),
+            AppAction::LoginAction(LoginAction::Logout) => {
+                let mut events = forward_action(LoginAction::Logout, &mut self.logged_user);
+                if let Some(home) = self.browser.home_state_mut() {
+                    home.albums.replace_all(std::iter::empty());
+                    home.playlists.replace_all(std::iter::empty());
+                    home.saved_tracks.clear().commit();
+                }
+                events.extend(forward_action(
+                    BrowserAction::NavigationPopTo(ScreenName::Home),
+                    &mut self.browser,
+                ));
+                self.playback = Default::default();
+                events.push(BrowserEvent::LibraryUpdated.into());
+                events.push(BrowserEvent::SavedPlaylistsUpdated.into());
+                events.push(BrowserEvent::SavedTracksUpdated.into());
+                events
+            }
             AppAction::LoginAction(a) => forward_action(a, &mut self.logged_user),
             AppAction::SettingsAction(a) => forward_action(a, &mut self.settings),
             _ => vec![],

--- a/src/player/oauth2.rs
+++ b/src/player/oauth2.rs
@@ -158,6 +158,10 @@ impl RiffOauthClient {
         Ok(token)
     }
 
+    pub async fn clear_credentials(&self) {
+        self.token_store.clear().await;
+    }
+
     pub async fn get_valid_token(&self) -> Result<Credentials, OAuthError> {
         let token = self.token_store.get().await.ok_or(OAuthError::LoggedOut)?;
         if token.token_expired() {

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -192,10 +192,10 @@ impl SpotifyPlayer {
                 Ok(())
             }
             Command::Logout => {
-                self.session
-                    .take()
-                    .ok_or(SpotifyError::PlayerNotReady)?
-                    .shutdown();
+                self.oauth_client.clear_credentials().await;
+                if let Some(session) = self.session.take() {
+                    session.shutdown();
+                }
                 let _ = self.player.take();
                 Ok(())
             }


### PR DESCRIPTION
## Summary
Improves the logout flow so the user is left in a clean state after signing out, rather than seeing stale data from the previous session.
  
## Changes
- Clear app state on logout (app_state.rs): When LoginAction::Logout is dispatched, the home state's albums, playlists, and saved tracks are cleared, playback is reset, the browser navigates back to the home screen, and update events are emitted so the UI reflects the empty state.
- Clear OAuth credentials (oauth2.rs, player.rs): Added clear_credentials() to RiffOauthClient and call it during logout so the keyring token is removed. The session shutdown is now graceful (no error if  session was already gone).
- Defer data loading to login (library.rs, saved_playlists.rs, saved_tracks.rs): Removed eager data fetching on AppEvent::Started; data is now only loaded on LoginCompleted, preventing stale data from appearing before authentication.
 - Refactor batch_loader retry logic (batch_loader.rs): Deduplicated the retry-on-invalid-token logic using a closure.  
 - Login window fix (login.rs): Changed close propagation to Proceed and simplified the application reference.
  
## Testing
 - Verified logout clears all visible content (albums, playlists, tracks) and returns the user to the home screen.
 - Verified re-login correctly reloads all content.
- Verified credentials are removed from the keyring after logout.