### PR TITLE
Fix GTK CSS warnings logged on startup

### DIFF
--- a/src/app/components/shell/playback/playback.css
+++ b/src/app/components/shell/playback/playback.css
@@ -1,7 +1,8 @@
 .seek-bar {
   padding: 0;
   margin: -16px -12px -16px -12px;
-  min-height: 1px;
+  min-height: 33px;
+  min-width: 25px;
 }
 
 .seek-bar trough {
@@ -40,6 +41,8 @@
 .playing-image {
   border-radius: 6px;
   margin: -4px 0 -4px -8px;
+  min-height: 9px;
+  min-width: 9px;
 }
 
 .mobile-now-playing {
@@ -57,4 +60,5 @@
   padding: 4px 8px;
   font-size: 1em;
   margin-top: -32px;
+  min-height: 33px;
 }

--- a/src/app/components/widgets/details_page/style.css
+++ b/src/app/components/widgets/details_page/style.css
@@ -33,7 +33,7 @@
   background-color: @skeleton_color;
   color: transparent;
   border-radius: 4px;
-  min-width: 24ch;
+  min-width: 192px;
   animation: skeleton-pulse 1.5s ease-in-out infinite;
 }
 
@@ -41,7 +41,7 @@
   background-color: @skeleton_color;
   color: transparent;
   border-radius: 4px;
-  min-width: 12ch;
+  min-width: 96px;
   animation: skeleton-pulse 1.5s ease-in-out infinite;
 }
 
@@ -49,7 +49,7 @@
   background-color: @skeleton_color;
   color: transparent;
   border-radius: 4px;
-  min-width: 8ch;
+  min-width: 64px;
   animation: skeleton-pulse 1.5s ease-in-out infinite;
 }
 


### PR DESCRIPTION
Replace CSS values that trigger GTK warnings at startup:

- Add explicit min-height/min-width to playback widgets (seek bar, album art, mobile now-playing bar)
- Replace ch units with px in skeleton loading placeholders, as GTK doesn't support ch