### PR TITLE
Updated About page with improved issue reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,15 +22,25 @@ If applicable, add screenshots to help explain your problem.
 
 **General information:**
  - Distribution:
- - Installation method [e. g. built from source, installed from Flathub...]:
- - Version [e.g. 0.1.0]:
- - Device used [e. g. desktop, phone...]:
+ - Installation method [e.g. Flatpak, built from source]:
+ - Riff Version:
+ - Arch [e.g. x86_64, aarch64]:
+ - Desktop [e.g. GNOME, KDE]:
+ - Display server [e.g. wayland, x11]:
+ - Device used [e.g. desktop, phone]:
 
-**Stack trace:**
-If applicable, run the application from a terminal and paste relevant log output.
+**Logs:**
+Please paste relevant log output below. You can retrieve logs with:
+```sh
+journalctl --user _COMM=riff --since="1 hour ago" --no-pager
 ```
-flatpak run --env=RUST_BACKTRACE=full dev.diegovsky.Riff
+<details><summary>Log output</summary>
+
 ```
+(paste logs here)
+```
+
+</details>
 
 **Additional context**
 Add any other context about the problem here.

--- a/src/about.rs
+++ b/src/about.rs
@@ -1,0 +1,123 @@
+use crate::config;
+
+pub fn setup_about(about: libadwaita::AboutDialog) {
+    setup_credits(&about);
+    setup_issue_link(&about);
+}
+
+fn setup_credits(about: &libadwaita::AboutDialog) {
+    let authors: Vec<&str> = include_str!("../AUTHORS")
+        .trim_end_matches('\n')
+        .split('\n')
+        .collect();
+    let translators = include_str!("../TRANSLATORS").trim_end_matches('\n');
+    let artists: Vec<&str> = include_str!("../ARTISTS")
+        .trim_end_matches('\n')
+        .split('\n')
+        .collect();
+    about.set_version(config::VERSION);
+    about.set_developers(&authors);
+    about.set_translator_credits(translators);
+    about.set_artists(&artists);
+}
+
+fn setup_issue_link(about: &libadwaita::AboutDialog) {
+    about.connect_activate_link(|_, uri| {
+        if uri.starts_with("https://github.com/Diegovsky/riff/issues") {
+            let system_info = gather_system_info();
+            let body = format!(
+                "**Describe the bug**\n\
+                 A clear and concise description of what the bug is.\n\n\
+                 **To Reproduce**\n\
+                 Steps to reproduce the behavior:\n\
+                 1. Go to '...'\n\
+                 2. Click on '....'\n\
+                 3. Scroll down to '....'\n\
+                 4. See error\n\n\
+                 **Screenshots**\n\
+                 If applicable, add screenshots to help explain your problem.\n\n\
+                 **General information:**\n\
+                 - Distribution: {distro}\n\
+                 - Installation method: {install_method}\n\
+                 - Riff Version: {version}\n\
+                 - Arch: {arch}\n\
+                 - Desktop: {desktop}\n\
+                 - Display server: {display_server}\n\
+                 - Device used: \n\n\
+                 **Logs:**\n\
+                 Please paste relevant log output below. You can retrieve logs with:\n\
+                 ```sh\n\
+                 journalctl --user _COMM=riff --since=\"1 hour ago\" --no-pager\n\
+                 ```\n\
+                 <details><summary>Log output</summary>\n\n\
+                 ```\n\
+                 (paste logs here)\n\
+                 ```\n\n\
+                 </details>\n\n\
+                 **Additional context**\n\
+                 Add any other context about the problem here.",
+                distro = system_info.distro,
+                install_method = system_info.install_method,
+                version = system_info.version,
+                arch = system_info.arch,
+                desktop = system_info.desktop,
+                display_server = system_info.display_server,
+            );
+
+            let url = format!(
+                "https://github.com/Diegovsky/riff/issues/new?labels=bug&body={}",
+                percent_encoding::utf8_percent_encode(&body, percent_encoding::NON_ALPHANUMERIC)
+            );
+
+            let _ = open::that(&url);
+            true
+        } else {
+            false
+        }
+    });
+}
+
+struct SystemInfo {
+    version: String,
+    distro: String,
+    arch: String,
+    desktop: String,
+    display_server: String,
+    install_method: String,
+}
+
+fn gather_system_info() -> SystemInfo {
+    let version = config::VERSION.to_string();
+    let arch = std::env::consts::ARCH.to_string();
+
+    let distro = std::fs::read_to_string("/etc/os-release")
+        .ok()
+        .and_then(|contents| {
+            contents
+                .lines()
+                .find(|line| line.starts_with("PRETTY_NAME="))
+                .map(|line| {
+                    line.trim_start_matches("PRETTY_NAME=")
+                        .trim_matches('"')
+                        .to_string()
+                })
+        })
+        .unwrap_or_else(|| format!("{} {}", std::env::consts::OS, arch));
+
+    let desktop = std::env::var("XDG_CURRENT_DESKTOP").unwrap_or_default();
+    let display_server = std::env::var("XDG_SESSION_TYPE").unwrap_or_default();
+    let install_method = if std::path::Path::new("/.flatpak-info").exists() {
+        "Flatpak".to_string()
+    } else {
+        "Native".to_string()
+    };
+
+    SystemInfo {
+        version,
+        distro,
+        arch,
+        desktop,
+        display_server,
+        install_method,
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use gio::ApplicationFlags;
 use gio::SimpleAction;
 use gtk::prelude::*;
 
+mod about;
 mod api;
 mod app;
 mod config;
@@ -53,7 +54,7 @@ fn main() {
 
     // Couple of actions used with shortcuts
     register_actions(&gtk_app, sender.clone());
-    setup_credits(builder.object::<libadwaita::AboutDialog>("about").unwrap());
+    about::setup_about(builder.object::<libadwaita::AboutDialog>("about").unwrap());
 
     // Main app logic is hooked up here
     let app = App::new(
@@ -144,23 +145,6 @@ fn setup_gtk(settings: &settings::RiffSettings) {
             gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
         );
     }
-}
-
-fn setup_credits(about: libadwaita::AboutDialog) {
-    // Read from a couple files at compile time and update the about dialog
-    let authors: Vec<&str> = include_str!("../AUTHORS")
-        .trim_end_matches('\n')
-        .split('\n')
-        .collect();
-    let translators = include_str!("../TRANSLATORS").trim_end_matches('\n');
-    let artists: Vec<&str> = include_str!("../ARTISTS")
-        .trim_end_matches('\n')
-        .split('\n')
-        .collect();
-    about.set_version(config::VERSION);
-    about.set_developers(&authors);
-    about.set_translator_credits(translators);
-    about.set_artists(&artists);
 }
 
 fn register_actions(app: &gtk::Application, sender: UnboundedSender<AppAction>) {

--- a/src/window.blp
+++ b/src/window.blp
@@ -139,7 +139,9 @@ Adw.ApplicationWindow window {
 
 Adw.AboutDialog about {
   application-name: "Riff";
-  website: "https://github.com/Diegovsky/riff";
   application-icon: "dev.diegovsky.Riff";
+  website: "https://github.com/Diegovsky/riff";
+  support-url: "https://discord.gg/rAAvFSC7VQ";
+  issue-url: "https://github.com/Diegovsky/riff/issues";
   license-type: mit_x11;
 }


### PR DESCRIPTION
Adds community links (GitHub, Discord, GitHub Issues) to the About dialog and enhances the "Report an Issue" button to open a pre-filled bug report with auto-detected system information.

Changes:

- About dialog now shows GitHub (website), Discord (support), and GitHub Issues (report) links directly on the main page
- Clicking "Report an Issue" intercepts the link and opens the browser with a pre-filled bug report template matching .github/ISSUE_TEMPLATE/bug_report.md
- System info (distro, version, arch, desktop environment, display server, install method) is auto-populated
- Updated bug report template with journalctl command for retrieving logs
- Extracted about dialog logic into src/about.rs

__Updated About Menu__
<img width="367" height="620" alt="Screenshot From 2026-07-10 14-56-42" src="https://github.com/user-attachments/assets/48042d80-ca51-44ac-8f21-6b3b15cb43e6" />

__Report Issue with Template and Auto Fields__
<img width="1631" height="1282" alt="Screenshot From 2026-07-10 14-57-26" src="https://github.com/user-attachments/assets/f7a52436-1d7a-4388-b960-0162bee8fad4" />
