### PR TITLE
Resolved more GTK warning messages

### DIFF
--- a/.github/workflows/riff-quality.yml
+++ b/.github/workflows/riff-quality.yml
@@ -26,6 +26,18 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  blueprint-lint:
+    name: "Blueprint Lint"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt-get -y update && sudo apt-get -y install blueprint-compiler libxml2-utils python3 gir1.2-gtk-4.0 gir1.2-adw-1
+
+      - name: Run blueprint lint
+        run: ./scripts/lint-blueprints.sh
+
   shellcheck:
     name: "ShellCheck"
     runs-on: ubuntu-latest

--- a/scripts/lint-blueprints.sh
+++ b/scripts/lint-blueprints.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lint Blueprint UI files for patterns that cause GTK runtime warnings.
+#
+# Checks:
+# 1. All .blp files compile without errors.
+# 2. GtkStack does not set visible-child-name as a property (it fires before
+#    children are added, causing "Child name 'X' not found in GtkStack").
+# 3. Children of GtkBox/GtkBoxLayout do not use Grid layout properties
+#    (causes "GtkBoxLayout does not create GtkLayoutChild instances").
+#
+# Usage: ./scripts/lint-blueprints.sh [path-to-search]
+
+SEARCH_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)/src}"
+FAILED=0
+
+if ! command -v blueprint-compiler &>/dev/null; then
+    echo "ERROR: blueprint-compiler not found. Install it to run this check."
+    exit 1
+fi
+
+if ! command -v xmllint &>/dev/null; then
+    echo "ERROR: xmllint not found. Install libxml2-utils (Debian) or libxml2 (Fedora/Arch)."
+    exit 1
+fi
+
+BLP_FILES=$(find "$SEARCH_DIR" -type f -name "*.blp")
+
+if [[ -z "$BLP_FILES" ]]; then
+    echo "No .blp files found in $SEARCH_DIR"
+    exit 0
+fi
+
+echo "--- Blueprint compilation ---"
+for blp in $BLP_FILES; do
+    if ! blueprint-compiler compile "$blp" > /dev/null 2>&1; then
+        echo "FAIL: $blp does not compile"
+        blueprint-compiler compile "$blp" 2>&1 || true
+        FAILED=1
+    fi
+done
+if [[ "$FAILED" -eq 0 ]]; then
+    echo "PASS: all .blp files compile"
+fi
+
+echo ""
+echo "--- GtkStack visible-child-name check ---"
+# In compiled UI XML, a <property name="visible-child-name"> on a GtkStack
+# is set before children are added, triggering runtime warnings.
+for blp in $BLP_FILES; do
+    XML=$(blueprint-compiler compile "$blp" 2>/dev/null) || continue
+
+    # Find GtkStack objects that set visible-child-name as a direct property.
+    # We use xmllint with xpath to find these.
+    MATCHES=$(echo "$XML" | xmllint --xpath \
+        '//object[@class="GtkStack"]/property[@name="visible-child-name"]' - 2>/dev/null) || MATCHES=""
+
+    if [[ -n "$MATCHES" ]]; then
+        echo "FAIL: $blp"
+        echo "  GtkStack sets visible-child-name as a property (will warn at runtime)."
+        echo "  Remove visible-child-name from the Stack; the first child is shown by default."
+        echo "  Use a Breakpoint setter or code to switch pages after construction."
+        FAILED=1
+    fi
+done
+if [[ "$FAILED" -eq 0 ]]; then
+    echo "PASS: no GtkStack visible-child-name property issues"
+fi
+
+echo ""
+echo "--- Box child layout property check ---"
+# A <layout> block inside a child of GtkBox can only use Box layout properties.
+# Grid properties (column, row, column-span, row-span) inside a Box child cause
+# "GtkBoxLayout does not create GtkLayoutChild instances".
+
+for blp in $BLP_FILES; do
+    XML=$(blueprint-compiler compile "$blp" 2>/dev/null) || continue
+
+    # Use a Python one-liner to walk the XML tree and find layout blocks
+    # under children of GtkBox that contain Grid properties.
+    ISSUES=$(python3 -c "
+import sys
+import xml.etree.ElementTree as ET
+
+xml_input = sys.stdin.read()
+tree = ET.fromstring(xml_input)
+issues = []
+
+def check_box_children(box_elem, path=''):
+    \"\"\"Check direct children of a GtkBox for invalid layout properties.\"\"\"
+    for child in box_elem.findall('child'):
+        obj = child.find('object')
+        if obj is None:
+            continue
+        obj_id = obj.get('id', obj.get('class', 'unknown'))
+        layout = obj.find('layout')
+        if layout is not None:
+            for prop in layout.findall('property'):
+                name = prop.get('name', '')
+                if name in ('column', 'row', 'column-span', 'row-span'):
+                    issues.append(f'  {obj_id}: layout property \"{name}\" invalid inside Box')
+
+def walk(elem):
+    if elem.tag == 'object' and elem.get('class') in ('GtkBox',):
+        check_box_children(elem)
+    # Also check template if it extends GtkBox
+    if elem.tag == 'template' and elem.get('parent') == 'GtkBox':
+        check_box_children(elem)
+    for child_elem in elem:
+        walk(child_elem)
+
+walk(tree)
+for issue in issues:
+    print(issue)
+" <<< "$XML" 2>/dev/null) || ISSUES=""
+
+    if [[ -n "$ISSUES" ]]; then
+        echo "FAIL: $blp"
+        echo "$ISSUES"
+        FAILED=1
+    fi
+done
+if [[ "$FAILED" -eq 0 ]]; then
+    echo "PASS: no invalid layout properties in Box children"
+fi
+
+echo ""
+if [[ "$FAILED" -ne 0 ]]; then
+    echo "Blueprint lint checks FAILED."
+    exit 1
+else
+    echo "All blueprint lint checks passed."
+fi

--- a/src/app/components/pages/login/login.blp
+++ b/src/app/components/pages/login/login.blp
@@ -65,7 +65,6 @@ template $LoginWindow : Adw.Window {
           Stack status_stack {
             transition-type: crossfade;
             transition-duration: 200;
-            visible-child-name: "notice";
 
             StackPage {
               name: "notice";

--- a/src/app/components/shell/playback/playback.css
+++ b/src/app/components/shell/playback/playback.css
@@ -59,6 +59,5 @@
   border-radius: 6px 6px 0 0;
   padding: 4px 8px;
   font-size: 1em;
-  margin-top: -32px;
-  min-height: 33px;
+  margin-top: -28px;
 }

--- a/src/app/components/shell/playback/playback_widget.blp
+++ b/src/app/components/shell/playback/playback_widget.blp
@@ -63,7 +63,6 @@ template $PlaybackWidget : Box {
     }
 
     child: Stack layout-stack {
-      visible-child-name: "desktop";
       vhomogeneous: false;
       hhomogeneous: false;
 
@@ -107,7 +106,6 @@ template $PlaybackWidget : Box {
           }
 
           Stack volume-stack {
-            visible-child-name: "slider";
             hexpand: true;
             halign: end;
 
@@ -130,11 +128,6 @@ template $PlaybackWidget : Box {
                   show-fill-level: true;
                   restrict-to-fill-level: false;
                   value-pos: left;
-                  layout {
-                    column-span: "1";
-                    column: 2;
-                    row: "0";
-                  }
 
                   styles [
                     'volume-slider'


### PR DESCRIPTION
Remove visible-child-name properties from GtkStack widgets (set before children are added, causing "Child name not found" warnings) and remove invalid Grid layout properties from a Box child in the playback widget. Adjust playback CSS margins accordingly.

Adds scripts/lint-blueprints.sh to catch these patterns in Blueprint files going forward.

Fixed minor css issue with playback seekbar.