### PR TITLE
Fix redundant Player::play called from invalid state

### DIFF
--- a/src/app/components/shell/playback/component.rs
+++ b/src/app/components/shell/playback/component.rs
@@ -182,6 +182,7 @@ impl EventListener for PlaybackControl {
                 self.update_shuffled();
             }
             AppEvent::PlaybackEvent(PlaybackEvent::TrackChanged(_)) => {
+                self.update_playing();
                 self.update_current_info();
             }
             AppEvent::PlaybackEvent(PlaybackEvent::PlaybackStopped) => {

--- a/src/app/components/widgets/details_page/model.rs
+++ b/src/app/components/widgets/details_page/model.rs
@@ -354,9 +354,9 @@ mod tests {
     }
 
     #[test]
-    fn test_is_playback_event_other() {
+    fn test_is_playback_event_track_changed() {
         let event = AppEvent::PlaybackEvent(PlaybackEvent::TrackChanged("x".to_string()));
-        assert_eq!(is_playback_event(&event), None);
+        assert_eq!(is_playback_event(&event), Some(true));
     }
 
     #[test]

--- a/src/app/components/widgets/details_page/traits.rs
+++ b/src/app/components/widgets/details_page/traits.rs
@@ -105,11 +105,12 @@ pub trait PageModel {
 }
 
 /// Check if a playback event means we should update the play button.
-/// Returns `Some(true)` for resumed, `Some(false)` for paused, `None` otherwise.
+/// Returns `Some(true)` for resumed/track changed, `Some(false)` for paused, `None` otherwise.
 pub fn is_playback_event(event: &AppEvent) -> Option<bool> {
     match event {
         AppEvent::PlaybackEvent(PlaybackEvent::PlaybackPaused) => Some(false),
-        AppEvent::PlaybackEvent(PlaybackEvent::PlaybackResumed) => Some(true),
+        AppEvent::PlaybackEvent(PlaybackEvent::PlaybackResumed)
+        | AppEvent::PlaybackEvent(PlaybackEvent::TrackChanged(_)) => Some(true),
         _ => None,
     }
 }

--- a/src/app/components/widgets/playlist/playlist.rs
+++ b/src/app/components/widgets/playlist/playlist.rs
@@ -247,6 +247,7 @@ where
                 self.update_list();
             }
             AppEvent::PlaybackEvent(PlaybackEvent::TrackChanged(_)) => {
+                Self::set_paused(&self.listview, self.model.is_paused());
                 self.update_list();
             }
             AppEvent::PlaybackEvent(

--- a/src/app/state/playback_state.rs
+++ b/src/app/state/playback_state.rs
@@ -404,10 +404,7 @@ impl UpdatableState for PlaybackState {
             }
             PlaybackAction::Next => {
                 if let Some(id) = self.play_next() {
-                    vec![
-                        PlaybackEvent::TrackChanged(id),
-                        PlaybackEvent::PlaybackResumed,
-                    ]
+                    vec![PlaybackEvent::TrackChanged(id)]
                 } else {
                     self.stop();
                     vec![PlaybackEvent::PlaybackStopped]
@@ -419,20 +416,14 @@ impl UpdatableState for PlaybackState {
             }
             PlaybackAction::Previous => {
                 if let Some(id) = self.play_prev() {
-                    vec![
-                        PlaybackEvent::TrackChanged(id),
-                        PlaybackEvent::PlaybackResumed,
-                    ]
+                    vec![PlaybackEvent::TrackChanged(id)]
                 } else {
                     vec![PlaybackEvent::TrackSeeked(0)]
                 }
             }
             PlaybackAction::Load(id) => {
                 if self.play(&id) {
-                    vec![
-                        PlaybackEvent::TrackChanged(id),
-                        PlaybackEvent::PlaybackResumed,
-                    ]
+                    vec![PlaybackEvent::TrackChanged(id)]
                 } else {
                     vec![]
                 }

--- a/src/dbus/listener.rs
+++ b/src/dbus/listener.rs
@@ -76,44 +76,47 @@ impl AppPlaybackStateListener {
         }
     }
 
-    fn update_for(&self, event: &PlaybackEvent) -> Option<MprisStateUpdate> {
+    fn update_for(&self, event: &PlaybackEvent) -> Vec<MprisStateUpdate> {
         match event {
             PlaybackEvent::PlaybackPaused => {
-                Some(MprisStateUpdate::SetPlaying(PlaybackStatus::Paused))
+                vec![MprisStateUpdate::SetPlaying(PlaybackStatus::Paused)]
             }
             PlaybackEvent::PlaybackResumed => {
-                Some(MprisStateUpdate::SetPlaying(PlaybackStatus::Playing))
+                vec![MprisStateUpdate::SetPlaying(PlaybackStatus::Playing)]
             }
             PlaybackEvent::PlaybackStopped => {
-                Some(MprisStateUpdate::SetPlaying(PlaybackStatus::Stopped))
+                vec![MprisStateUpdate::SetPlaying(PlaybackStatus::Stopped)]
             }
             PlaybackEvent::TrackChanged(_) => {
                 let current = self.make_track_meta();
                 let (has_prev, has_next) = self.has_prev_next();
-                Some(MprisStateUpdate::SetCurrentTrack {
-                    has_prev,
-                    has_next,
-                    current,
-                })
+                vec![
+                    MprisStateUpdate::SetCurrentTrack {
+                        has_prev,
+                        has_next,
+                        current,
+                    },
+                    MprisStateUpdate::SetPlaying(PlaybackStatus::Playing),
+                ]
             }
             PlaybackEvent::RepeatModeChanged(_) => {
                 let loop_status = self.loop_status();
                 let (has_prev, has_next) = self.has_prev_next();
-                Some(MprisStateUpdate::SetLoopStatus {
+                vec![MprisStateUpdate::SetLoopStatus {
                     has_prev,
                     has_next,
                     loop_status,
-                })
+                }]
             }
             PlaybackEvent::ShuffleChanged(shuffled) => {
-                Some(MprisStateUpdate::SetShuffled(*shuffled))
+                vec![MprisStateUpdate::SetShuffled(*shuffled)]
             }
             PlaybackEvent::TrackSeeked(pos) | PlaybackEvent::SeekSynced(pos) => {
                 let pos = 1000 * (*pos as u128);
-                Some(MprisStateUpdate::SetPositionMs(pos))
+                vec![MprisStateUpdate::SetPositionMs(pos)]
             }
-            PlaybackEvent::VolumeSet(vol) => Some(MprisStateUpdate::SetVolume(*vol)),
-            _ => None,
+            PlaybackEvent::VolumeSet(vol) => vec![MprisStateUpdate::SetVolume(*vol)],
+            _ => vec![],
         }
     }
 }
@@ -121,7 +124,7 @@ impl AppPlaybackStateListener {
 impl EventListener for AppPlaybackStateListener {
     fn on_event(&mut self, event: &AppEvent) {
         if let AppEvent::PlaybackEvent(event) = event {
-            if let Some(update) = self.update_for(event) {
+            for update in self.update_for(event) {
                 if let Err(e) = self.sender.unbounded_send(update) {
                     log::error!("Could not send event to DBUS server: {e}");
                 }


### PR DESCRIPTION
### Problem

librespot logs Player::play called from invalid state: Playing on every track transition (next, previous, or load). This happens because the state reducer emits both TrackChanged and PlaybackResumed together. TrackChanged triggers player.load(track, resume=true) which already starts playback, then PlaybackResumed triggers a redundant player.play() while the player is already in the Playing state.

### Solution

Remove PlaybackResumed from the event vectors emitted by Next, Previous, and Load actions in the reducer. A TrackChanged event always implies playback has started (the underlying state sets is_playing = true), so the separate PlaybackResumed was redundant for the player. PlaybackResumed now purely means "user unpaused."

UI components and the MPRIS listener are updated to also derive the playing state from TrackChanged, so play/pause buttons and D-Bus status remain correct.

### Changes

- playback_state.rs: Remove PlaybackResumed from Next/Previous/Load results
- playback/component.rs: Call update_playing() on TrackChanged
- playlist.rs: Call set_paused() on TrackChanged
- details_page/traits.rs: Treat TrackChanged as a playing indicator
- dbus/listener.rs: Emit SetPlaying(Playing) alongside SetCurrentTrack on TrackChanged

### Related 
https://github.com/Diegovsky/riff/issues/49