### PR TITLE
Add close window behavior dialog and setting

### DIFF
--- a/data/dev.diegovsky.Riff.gschema.xml
+++ b/data/dev.diegovsky.Riff.gschema.xml
@@ -15,6 +15,11 @@
     <value value="1" nick="dark" />
     <value value="2" nick="system" />
   </enum>
+  <enum id="dev.diegovsky.Riff.CloseWindowBehavior">
+    <value value="0" nick="ask" />
+    <value value="1" nick="minimize-to-background" />
+    <value value="2" nick="stop-and-quit" />
+  </enum>
   <schema id="dev.diegovsky.Riff" path="/dev/diegovsky/Riff/">
     <key name='theme-preference' enum='dev.diegovsky.Riff.ThemePref'>
       <default>'system'</default>
@@ -31,6 +36,10 @@
     <key name="window-is-maximized" type="b">
       <default>false</default>
       <summary>A flag to enable maximized mode</summary>
+    </key>
+    <key name='close-window-behavior' enum='dev.diegovsky.Riff.CloseWindowBehavior'>
+      <default>'ask'</default>
+      <summary>Behavior when the window close button is pressed while playing</summary>
     </key>
     <key name='player-bitrate' enum='dev.diegovsky.Riff.Bitrate'>
       <default>'160'</default>

--- a/src/app/components/pages/settings/settings.blp
+++ b/src/app/components/pages/settings/settings.blp
@@ -6,6 +6,42 @@ template $SettingsWindow : Adw.PreferencesDialog {
 
   Adw.PreferencesPage {
     Adw.PreferencesGroup {
+      /* Translators: Header for a group of preference items regarding the application's appearance and behavior */
+
+      title: _("General");
+
+      Adw.ComboRow theme {
+        /* Translators: Title for an item in preferences */
+
+        title: _("Theme");
+        model: StringList {
+          strings [
+            _("Light"),
+            _("Dark"),
+            _("System")
+          ]
+        };
+      }
+
+      Adw.ComboRow close_behavior {
+        /* Translators: Title for an item in preferences */
+
+        title: _("Close Window Behavior");
+
+        /* Translators: Description for the close window behavior preference */
+
+        subtitle: _("What should Riff do if you close it while audio is playing?");
+        model: StringList {
+          strings [
+            _("Ask"),
+            _("Continue in background"),
+            _("Stop and quit")
+          ]
+        };
+      }
+    }
+
+    Adw.PreferencesGroup {
       /* Translators: Header for a group of preference items regarding audio */
 
       title: _("Audio");
@@ -62,25 +98,6 @@ template $SettingsWindow : Adw.PreferencesDialog {
           margin-top: 12;
           margin-bottom: 12;
         }
-      }
-    }
-
-    Adw.PreferencesGroup {
-      /* Translators: Header for a group of preference items regarding the application's appearance */
-
-      title: _("Appearance");
-
-      Adw.ComboRow theme {
-        /* Translators: Title for an item in preferences */
-
-        title: _("Theme");
-        model: StringList {
-          strings [
-            _("Light"),
-            _("Dark"),
-            _("System")
-          ]
-        };
       }
     }
 

--- a/src/app/components/pages/settings/settings.rs
+++ b/src/app/components/pages/settings/settings.rs
@@ -40,6 +40,9 @@ mod imp {
 
         #[template_child]
         pub theme: TemplateChild<libadwaita::ComboRow>,
+
+        #[template_child]
+        pub close_behavior: TemplateChild<libadwaita::ComboRow>,
     }
 
     #[glib::object_subclass]
@@ -212,6 +215,36 @@ impl SettingsDialog {
                         0 => "light",
                         1 => "dark",
                         2 => "system",
+                        _ => unreachable!(),
+                    }
+                    .to_variant()
+                })
+            })
+            .build();
+
+        let close_behavior = widget
+            .close_behavior
+            .downcast_ref::<libadwaita::ComboRow>()
+            .unwrap();
+        settings
+            .bind("close-window-behavior", close_behavior, "selected")
+            .mapping(|variant, _| {
+                variant.str().map(|s| {
+                    match s {
+                        "ask" => 0,
+                        "minimize-to-background" => 1,
+                        "stop-and-quit" => 2,
+                        _ => unreachable!(),
+                    }
+                    .to_value()
+                })
+            })
+            .set_mapping(|value, _| {
+                value.get::<u32>().ok().map(|u| {
+                    match u {
+                        0 => "ask",
+                        1 => "minimize-to-background",
+                        2 => "stop-and-quit",
                         _ => unreachable!(),
                     }
                     .to_variant()

--- a/src/app/components/shell/window/mod.rs
+++ b/src/app/components/shell/window/mod.rs
@@ -1,10 +1,15 @@
+use gettextrs::gettext;
+use gio::prelude::SettingsExt;
 use gtk::prelude::*;
+use libadwaita::prelude::*;
 use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::app::components::EventListener;
 use crate::app::{AppEvent, AppModel};
-use crate::settings::WindowGeometry;
+use crate::settings::{CloseWindowBehavior, WindowGeometry};
+
+const SETTINGS: &str = "dev.diegovsky.Riff";
 
 thread_local! {
     static WINDOW_GEOMETRY: RefCell<WindowGeometry> = const { RefCell::new(WindowGeometry {
@@ -30,11 +35,25 @@ impl MainWindow {
             glib::Propagation::Proceed,
             move |window| {
                 let state = app_model.get_state();
-                if state.playback.is_playing() {
-                    window.set_visible(false);
-                    glib::Propagation::Stop
-                } else {
-                    glib::Propagation::Proceed
+                if !state.playback.is_playing() {
+                    return glib::Propagation::Proceed;
+                }
+
+                let settings = gio::Settings::new(SETTINGS);
+                let behavior = CloseWindowBehavior::from_gsettings_enum(
+                    settings.enum_("close-window-behavior"),
+                );
+
+                match behavior {
+                    CloseWindowBehavior::MinimizeToBackground => {
+                        window.set_visible(false);
+                        glib::Propagation::Stop
+                    }
+                    CloseWindowBehavior::StopAndQuit => glib::Propagation::Proceed,
+                    CloseWindowBehavior::Ask => {
+                        Self::show_close_dialog(window);
+                        glib::Propagation::Stop
+                    }
                 }
             }
         ));
@@ -52,6 +71,62 @@ impl MainWindow {
             initial_window_geometry,
             window,
         }
+    }
+
+    fn show_close_dialog(window: &libadwaita::ApplicationWindow) {
+        let dialog = libadwaita::AlertDialog::new(
+            Some(&gettext("Riff is still playing")),
+            Some(&gettext(
+                "What should Riff do if you close it while audio is playing?",
+            )),
+        );
+
+        dialog.add_response("background", &gettext("Continue in background"));
+        dialog.add_response("quit", &gettext("Stop audio and quit"));
+
+        dialog.set_response_appearance("quit", libadwaita::ResponseAppearance::Destructive);
+        dialog.set_default_response(Some("background"));
+        dialog.set_close_response("background");
+        dialog.set_prefer_wide_layout(true);
+
+        let remember_check = gtk::CheckButton::with_label(&gettext("Remember my choice"));
+        remember_check.set_halign(gtk::Align::Center);
+        dialog.set_extra_child(Some(&remember_check));
+
+        dialog.choose(
+            window,
+            None::<&gio::Cancellable>,
+            clone!(
+                #[weak]
+                window,
+                move |response| {
+                    let settings = gio::Settings::new(SETTINGS);
+                    match response.as_str() {
+                        "quit" => {
+                            if remember_check.is_active() {
+                                let _ = settings.set_enum(
+                                    "close-window-behavior",
+                                    CloseWindowBehavior::StopAndQuit as i32,
+                                );
+                            }
+                            if let Some(app) = window.application() {
+                                app.quit();
+                            }
+                        }
+                        _ => {
+                            // "background" or dialog dismissed
+                            if remember_check.is_active() {
+                                let _ = settings.set_enum(
+                                    "close-window-behavior",
+                                    CloseWindowBehavior::MinimizeToBackground as i32,
+                                );
+                            }
+                            window.set_visible(false);
+                        }
+                    }
+                }
+            ),
+        );
     }
 
     fn start(&self) {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,6 +13,24 @@ use librespot::playback::config::Bitrate;
 
 const SETTINGS: &str = "dev.diegovsky.Riff";
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CloseWindowBehavior {
+    #[default]
+    Ask,
+    MinimizeToBackground,
+    StopAndQuit,
+}
+
+impl CloseWindowBehavior {
+    pub fn from_gsettings_enum(value: i32) -> Self {
+        match value {
+            1 => Self::MinimizeToBackground,
+            2 => Self::StopAndQuit,
+            _ => Self::Ask,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct WindowGeometry {
     pub width: i32,


### PR DESCRIPTION
When Riff is closed while audio is playing, a dialog now asks the user how to proceed: stop playback and quit, or continue in the background.

### Changes:

- New CloseWindowBehavior enum and GSettings key (close-window-behavior) with options: ask, minimize-to-background, stop-and-quit
- Close dialog with inline buttons, destructive styling on "Stop audio and quit", and a centered "Remember my choice" checkbox
- New "Close Window Behavior" combo row in the General preferences group
- Moved theme preference into a new "General" group alongside the close behavior setting

### Images
__Dialog for when user closes window while Riff is playing audio__
<img width="489" height="229" alt="Screenshot From 2026-07-11 11-54-58" src="https://github.com/user-attachments/assets/887ff163-63bd-481a-95f3-c86bd1fa65ef" />

__Updated Settings Page__
<img width="641" height="924" alt="Screenshot From 2026-07-11 11-54-32" src="https://github.com/user-attachments/assets/ec07b211-f064-4d40-98ff-256488c27673" />


### Related
https://github.com/Diegovsky/riff/issues/125