### PR TITLE
Added ability to like songs

### DIFF
--- a/src/app/components/pages/now_playing/model.rs
+++ b/src/app/components/pages/now_playing/model.rs
@@ -219,6 +219,15 @@ impl PlaylistModel for NowPlayingModel {
         self.enable_selection_with_context(self.current_selection_context())
     }
 
+    fn is_song_liked(&self, id: &str) -> bool {
+        self.base.is_song_liked(id)
+    }
+
+    fn toggle_song_like(&self, id: &str) {
+        let songs = PlaylistModel::song_list_model(self);
+        self.base.toggle_song_like(&songs, id);
+    }
+
     fn actions_for(&self, id: &str) -> Option<gio::ActionGroup> {
         let queue = self.queue();
         let song = queue.songs().get(id)?;

--- a/src/app/components/widgets/details_page/model.rs
+++ b/src/app/components/widgets/details_page/model.rs
@@ -4,7 +4,9 @@ use std::rc::Rc;
 
 use crate::app::dispatch::ActionDispatcher;
 use crate::app::models::SongListModel;
-use crate::app::state::{PlaybackAction, SelectionAction, SelectionContext, SelectionState};
+use crate::app::state::{
+    BrowserAction, PlaybackAction, SelectionAction, SelectionContext, SelectionState,
+};
 use crate::app::{AppAction, AppModel, AppState};
 use crate::feature_flags::{self, FeatureFlag};
 
@@ -27,6 +29,13 @@ macro_rules! impl_playlist_model_base {
         }
         fn selection(&self) -> Option<Box<dyn Deref<Target = SelectionState> + '_>> {
             self.base.selection()
+        }
+        fn is_song_liked(&self, id: &str) -> bool {
+            self.base.is_song_liked(id)
+        }
+        fn toggle_song_like(&self, id: &str) {
+            let songs = PlaylistModel::song_list_model(self);
+            self.base.toggle_song_like(&songs, id);
         }
     };
 }
@@ -181,6 +190,40 @@ impl DetailsPageModel {
         };
         if let Some(song) = song_list.index(index) {
             play_song_at(index, &song.get_id());
+        }
+    }
+
+    // Liked song helpers
+
+    pub fn is_song_liked(&self, id: &str) -> bool {
+        let state = self.app_model.get_state();
+        if let Some(home) = state.browser.home_state() {
+            return home.saved_tracks.get(id).is_some();
+        }
+        false
+    }
+
+    pub fn toggle_song_like(&self, song_list: &SongListModel, id: &str) {
+        let Some(song) = song_list.get(id) else {
+            return;
+        };
+        let song_desc = song.into_description();
+        let song_id = song_desc.id.clone();
+        let api = self.app_model.get_spotify();
+        let is_liked = self.is_song_liked(id);
+
+        if is_liked {
+            self.dispatcher
+                .call_spotify_and_dispatch(move || async move {
+                    api.remove_saved_tracks(vec![song_id.clone()]).await?;
+                    Ok(BrowserAction::RemoveSavedTracks(vec![song_id]).into())
+                });
+        } else {
+            self.dispatcher
+                .call_spotify_and_dispatch(move || async move {
+                    api.save_tracks(vec![song_id]).await?;
+                    Ok(BrowserAction::SaveTracks(vec![song_desc]).into())
+                });
         }
     }
 }

--- a/src/app/components/widgets/playlist/playlist.rs
+++ b/src/app/components/widgets/playlist/playlist.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use crate::app::components::utils::{ancestor, AnimatorDefault};
 use crate::app::components::{Component, EventListener, SongWidget};
 use crate::app::models::{SongListModel, SongModel, SongState};
-use crate::app::state::{PlaybackEvent, SelectionEvent, SelectionState};
+use crate::app::state::{BrowserEvent, PlaybackEvent, SelectionEvent, SelectionState};
 use crate::app::{AppEvent, Worker};
 
 pub trait PlaylistModel {
@@ -49,15 +49,23 @@ pub trait PlaylistModel {
             .unwrap_or(false)
     }
 
+    fn is_song_liked(&self, _id: &str) -> bool {
+        false
+    }
+
+    fn toggle_song_like(&self, _id: &str) {}
+
     fn song_state(&self, id: &str) -> SongState {
         let is_playing = self.current_song_id().map(|s| s.eq(id)).unwrap_or(false);
         let is_selected = self
             .selection()
             .map(|s| s.is_song_selected(id))
             .unwrap_or(false);
+        let is_liked = self.is_song_liked(id);
         SongState {
             is_selected,
             is_playing,
+            is_liked,
         }
     }
 
@@ -113,9 +121,18 @@ where
                 let widget = item.child().unwrap().downcast::<SongWidget>().unwrap();
                 widget.bind(&song_model, worker.clone(), model.show_song_covers());
 
-                let id = &song_model.get_id();
-                widget.set_actions(model.actions_for(id).as_ref());
-                widget.set_menu(model.menu_for(id).as_ref());
+                let id = song_model.get_id();
+                widget.set_actions(model.actions_for(&id).as_ref());
+                widget.set_menu(model.menu_for(&id).as_ref());
+
+                let like_id = id.clone();
+                widget.connect_like(clone!(
+                    #[weak]
+                    model,
+                    move || {
+                        model.toggle_song_like(&like_id);
+                    }
+                ));
             }
         ));
 
@@ -123,6 +140,8 @@ where
             let item = item.downcast_ref::<gtk::ListItem>().unwrap();
             let song_model = item.item().unwrap().downcast::<SongModel>().unwrap();
             song_model.unbind_all();
+            let widget = item.child().unwrap().downcast::<SongWidget>().unwrap();
+            widget.disconnect_like();
         });
 
         listview.connect_activate(clone!(
@@ -230,10 +249,12 @@ impl SongModel {
         SongState {
             is_playing,
             is_selected,
+            is_liked,
         }: SongState,
     ) {
         self.set_playing(is_playing);
         self.set_selected(is_selected);
+        self.set_liked(is_liked);
     }
 }
 
@@ -257,6 +278,9 @@ where
             }
             AppEvent::SelectionEvent(SelectionEvent::SelectionModeChanged(_)) => {
                 Self::set_selection_active(&self.listview, self.model.is_selection_enabled());
+                self.update_list();
+            }
+            AppEvent::BrowserEvent(BrowserEvent::SavedTracksUpdated) => {
                 self.update_list();
             }
             _ => {}

--- a/src/app/components/widgets/playlist/song.blp
+++ b/src/app/components/widgets/playlist/song.blp
@@ -96,6 +96,27 @@ template $SongWidget : Grid {
     ]
   }
 
+  Button like_btn {
+    icon-name: "non-starred-symbolic";
+    has-frame: false;
+    hexpand: false;
+    halign: center;
+    valign: center;
+    tooltip-text: "Like";
+
+    layout {
+      row-span: "2";
+      column: "3";
+      row: "0";
+    }
+
+    styles [
+      "circular",
+      "flat",
+      "song__like",
+    ]
+  }
+
   Label song_length {
     sensitive: false;
     label: "0∶00";
@@ -106,7 +127,7 @@ template $SongWidget : Grid {
 
     layout {
       row-span: "2";
-      column: "3";
+      column: "4";
       row: "0";
     }
 
@@ -127,7 +148,7 @@ template $SongWidget : Grid {
 
     layout {
       row-span: "2";
-      column: "4";
+      column: "5";
       row: "0";
     }
 

--- a/src/app/components/widgets/playlist/song.css
+++ b/src/app/components/widgets/playlist/song.css
@@ -128,6 +128,28 @@ row:hover .song__menu--enabled, .song__menu--enabled:checked {
   opacity: 1;
 }
 
+/* Like button */
+.song__like {
+  opacity: 0;
+  transition: opacity 150ms ease;
+  min-width: 24px;
+  min-height: 24px;
+  margin-right: 8px;
+}
+
+row:hover .song__like {
+  opacity: 0.6;
+}
+
+row:hover .song__like:hover {
+  opacity: 1;
+}
+
+.song--liked .song__like {
+  opacity: 1;
+  color: alpha(currentColor, 0.55);
+}
+
 
 /* Song Labels */
 .song--playing label.title {

--- a/src/app/components/widgets/playlist/song.rs
+++ b/src/app/components/widgets/playlist/song.rs
@@ -14,6 +14,7 @@ mod imp {
     use super::*;
 
     const SONG_CLASS: &str = "song--playing";
+    const LIKED_CLASS: &str = "song--liked";
 
     #[derive(Debug, Default, CompositeTemplate)]
     #[template(resource = "/dev/diegovsky/Riff/components/song.ui")]
@@ -37,10 +38,15 @@ mod imp {
         pub song_length: TemplateChild<gtk::Label>,
 
         #[template_child]
+        pub like_btn: TemplateChild<gtk::Button>,
+
+        #[template_child]
         pub menu_btn: TemplateChild<gtk::MenuButton>,
 
         #[template_child]
         pub song_cover: TemplateChild<gtk::Image>,
+
+        pub like_handler_id: std::cell::RefCell<Option<glib::SignalHandlerId>>,
     }
 
     #[glib::object_subclass]
@@ -59,9 +65,10 @@ mod imp {
     }
 
     lazy_static! {
-        static ref PROPERTIES: [glib::ParamSpec; 2] = [
+        static ref PROPERTIES: [glib::ParamSpec; 3] = [
             glib::ParamSpecBoolean::builder("playing").build(),
-            glib::ParamSpecBoolean::builder("selected").build()
+            glib::ParamSpecBoolean::builder("selected").build(),
+            glib::ParamSpecBoolean::builder("liked").build()
         ];
     }
 
@@ -88,6 +95,20 @@ mod imp {
                         .expect("type conformity checked by `Object::set_property`");
                     self.song_checkbox.set_active(is_selected);
                 }
+                "liked" => {
+                    let is_liked: bool = value
+                        .get()
+                        .expect("type conformity checked by `Object::set_property`");
+                    if is_liked {
+                        self.obj().add_css_class(LIKED_CLASS);
+                        self.like_btn.set_icon_name("starred-symbolic");
+                        self.like_btn.set_tooltip_text(Some("Unlike"));
+                    } else {
+                        self.obj().remove_css_class(LIKED_CLASS);
+                        self.like_btn.set_icon_name("non-starred-symbolic");
+                        self.like_btn.set_tooltip_text(Some("Like"));
+                    }
+                }
                 _ => unimplemented!(),
             }
         }
@@ -96,6 +117,7 @@ mod imp {
             match pspec.name() {
                 "playing" => self.obj().has_css_class(SONG_CLASS).to_value(),
                 "selected" => self.song_checkbox.is_active().to_value(),
+                "liked" => self.obj().has_css_class(LIKED_CLASS).to_value(),
                 _ => unimplemented!(),
             }
         }
@@ -144,6 +166,25 @@ impl SongWidget {
         }
     }
 
+    pub fn connect_like<F: Fn() + 'static>(&self, f: F) {
+        let widget = self.imp();
+        // Disconnect previous handler to avoid stacking handlers on widget reuse
+        if let Some(old_id) = widget.like_handler_id.borrow_mut().take() {
+            widget.like_btn.disconnect(old_id);
+        }
+        let handler_id = widget.like_btn.connect_clicked(move |_| {
+            f();
+        });
+        widget.like_handler_id.replace(Some(handler_id));
+    }
+
+    pub fn disconnect_like(&self) {
+        let widget = self.imp();
+        if let Some(handler_id) = widget.like_handler_id.borrow_mut().take() {
+            widget.like_btn.disconnect(handler_id);
+        }
+    }
+
     fn set_show_cover(&self, show_cover: bool) {
         let song_class = "song--cover";
         if show_cover {
@@ -187,6 +228,7 @@ impl SongWidget {
         model.bind_duration(&*widget.song_length, "label");
         model.bind_playing(self, "playing");
         model.bind_selected(self, "selected");
+        model.bind_liked(self, "liked");
 
         self.set_show_cover(show_cover);
         if show_cover {

--- a/src/app/models/main.rs
+++ b/src/app/models/main.rs
@@ -216,6 +216,7 @@ impl Hash for SongDescription {
 pub struct SongState {
     pub is_playing: bool,
     pub is_selected: bool,
+    pub is_liked: bool,
 }
 
 // A batch of SONGS

--- a/src/app/models/songs/song_model.rs
+++ b/src/app/models/songs/song_model.rs
@@ -27,12 +27,20 @@ impl SongModel {
         self.set_property("selected", is_selected);
     }
 
+    pub fn set_liked(&self, is_liked: bool) {
+        self.set_property("liked", is_liked);
+    }
+
     pub fn get_playing(&self) -> bool {
         self.property("playing")
     }
 
     pub fn get_selected(&self) -> bool {
         self.property("selected")
+    }
+
+    pub fn get_liked(&self) -> bool {
+        self.property("liked")
     }
 
     pub fn get_id(&self) -> String {
@@ -82,6 +90,14 @@ impl SongModel {
     pub fn bind_selected(&self, o: &impl ObjectType, property: &str) {
         self.imp().push_binding(
             self.bind_property("selected", o, property)
+                .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE)
+                .build(),
+        );
+    }
+
+    pub fn bind_liked(&self, o: &impl ObjectType, property: &str) {
+        self.imp().push_binding(
+            self.bind_property("liked", o, property)
                 .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE)
                 .build(),
         );
@@ -150,7 +166,7 @@ mod imp {
     }
 
     lazy_static! {
-        static ref PROPERTIES: [glib::ParamSpec; 8] = [
+        static ref PROPERTIES: [glib::ParamSpec; 9] = [
             glib::ParamSpecString::builder("id").read_only().build(),
             glib::ParamSpecUInt::builder("index").read_only().build(),
             glib::ParamSpecString::builder("title").read_only().build(),
@@ -167,6 +183,9 @@ mod imp {
             glib::ParamSpecBoolean::builder("selected")
                 .readwrite()
                 .build(),
+            glib::ParamSpecBoolean::builder("liked")
+                .readwrite()
+                .build(),
         ];
     }
 
@@ -181,20 +200,45 @@ mod imp {
                     let is_playing = value
                         .get()
                         .expect("type conformity checked by `Object::set_property`");
-                    let SongState { is_selected, .. } = self.state.get();
+                    let SongState {
+                        is_selected,
+                        is_liked,
+                        ..
+                    } = self.state.get();
                     self.state.set(SongState {
                         is_playing,
                         is_selected,
+                        is_liked,
                     });
                 }
                 "selected" => {
                     let is_selected = value
                         .get()
                         .expect("type conformity checked by `Object::set_property`");
-                    let SongState { is_playing, .. } = self.state.get();
+                    let SongState {
+                        is_playing,
+                        is_liked,
+                        ..
+                    } = self.state.get();
                     self.state.set(SongState {
                         is_playing,
                         is_selected,
+                        is_liked,
+                    });
+                }
+                "liked" => {
+                    let is_liked = value
+                        .get()
+                        .expect("type conformity checked by `Object::set_property`");
+                    let SongState {
+                        is_playing,
+                        is_selected,
+                        ..
+                    } = self.state.get();
+                    self.state.set(SongState {
+                        is_playing,
+                        is_selected,
+                        is_liked,
                     });
                 }
                 _ => unimplemented!(),
@@ -251,6 +295,7 @@ mod imp {
                     .to_value(),
                 "playing" => self.state.get().is_playing.to_value(),
                 "selected" => self.state.get().is_selected.to_value(),
+                "liked" => self.state.get().is_liked.to_value(),
                 _ => unimplemented!(),
             }
         }

--- a/src/app/models/songs/support.rs
+++ b/src/app/models/songs/support.rs
@@ -242,7 +242,12 @@ impl SongList {
             });
         self.last_batch_key = batches.len().saturating_sub(1);
         self.batches = batches;
-        let removed = ids.len();
+        // Drop the removed songs from the id->model lookup as well, otherwise
+        // `get()` would keep returning stale entries after removal.
+        let removed = ids
+            .iter()
+            .filter(|id| self.indexed_songs.remove(*id).is_some())
+            .count();
         self.total = self.total.saturating_sub(removed);
         self.total_loaded = self.total_loaded.saturating_sub(removed);
         // Lazy computation of the affected range, basically assume everything has changed
@@ -625,6 +630,21 @@ mod tests {
         assert_eq!(list_iter.next().unwrap().description().id, "song2");
         assert_eq!(list_iter.next().unwrap().description().id, "song3");
         assert!(list_iter.next().is_none());
+    }
+
+    #[test]
+    fn test_remove_clears_lookup() {
+        let mut list = SongList::new_from_initial_batch(batch(0));
+        list.add(batch(1));
+
+        assert!(list.get("song0").is_some());
+
+        list.remove(&["song0".to_string()]);
+
+        // `get` must not return songs that were removed, otherwise callers
+        // relying on membership (e.g. liked-song checks) get stale results.
+        assert!(list.get("song0").is_none());
+        assert!(list.get("song1").is_some());
     }
 
     #[test]


### PR DESCRIPTION
Adds a like/unlike button to song rows in playlist views. The button appears on hover, toggles liked state via the Spotify API, and stays visible for already-liked tracks.

__What's included___

- Star button in the song row widget with hover/liked CSS states
- is_liked property plumbed through SongState → SongModel → SongWidget
- toggle_song_like logic in DetailsPageModel that calls save_tracks / remove_saved_tracks
- PlaylistModel trait extended so all playlist views (including Now Playing) support liking
- Listens for SavedTracksUpdated events to keep UI in sync
- Fixed SongList::remove() not clearing the indexed lookup (caused stale liked-state results) + added test