### PR TITLE
emit items_changed synchronously and decouple bind callback from AppState

### DIFF
--- a/src/app/components/pages/details_album/model.rs
+++ b/src/app/components/pages/details_album/model.rs
@@ -225,9 +225,7 @@ impl PlaylistModel for DetailsModel {
         }
     }
 
-    fn actions_for(&self, id: &str) -> Option<gio::ActionGroup> {
-        let song = PlaylistModel::song_list_model(self).get(id)?;
-        let song = song.description();
+    fn actions_for(&self, song: &SongDescription) -> Option<gio::ActionGroup> {
         let group = SimpleActionGroup::new();
         for a in song.make_artist_actions(self.dispatcher.box_clone(), None) {
             group.add_action(&a);
@@ -237,9 +235,7 @@ impl PlaylistModel for DetailsModel {
         Some(group.upcast())
     }
 
-    fn menu_for(&self, id: &str) -> Option<gio::MenuModel> {
-        let song = PlaylistModel::song_list_model(self).get(id)?;
-        let song = song.description();
+    fn menu_for(&self, song: &SongDescription) -> Option<gio::MenuModel> {
         let menu = gio::Menu::new();
         for artist in song.artists.iter() {
             menu.append(

--- a/src/app/components/pages/details_artist/model.rs
+++ b/src/app/components/pages/details_artist/model.rs
@@ -224,9 +224,7 @@ impl PlaylistModel for ArtistDetailsModel {
             .dispatch(PlaybackAction::Load(id.to_string()).into());
     }
 
-    fn actions_for(&self, id: &str) -> Option<gio::ActionGroup> {
-        let song = PlaylistModel::song_list_model(self).get(id)?;
-        let song = song.description();
+    fn actions_for(&self, song: &SongDescription) -> Option<gio::ActionGroup> {
         let group = SimpleActionGroup::new();
         for a in song.make_artist_actions(self.dispatcher.box_clone(), None) {
             group.add_action(&a);
@@ -237,9 +235,7 @@ impl PlaylistModel for ArtistDetailsModel {
         Some(group.upcast())
     }
 
-    fn menu_for(&self, id: &str) -> Option<gio::MenuModel> {
-        let song = PlaylistModel::song_list_model(self).get(id)?;
-        let song = song.description();
+    fn menu_for(&self, song: &SongDescription) -> Option<gio::MenuModel> {
         let menu = gio::Menu::new();
         menu.append(Some(&*labels::VIEW_ALBUM), Some("song.view_album"));
         for artist in song.artists.iter().filter(|a| self.id != a.id) {

--- a/src/app/components/pages/details_playlist/model.rs
+++ b/src/app/components/pages/details_playlist/model.rs
@@ -261,9 +261,7 @@ impl PlaylistModel for PlaylistDetailsModel {
         }
     }
 
-    fn actions_for(&self, id: &str) -> Option<gio::ActionGroup> {
-        let song = PlaylistModel::song_list_model(self).get(id)?;
-        let song = song.description();
+    fn actions_for(&self, song: &SongDescription) -> Option<gio::ActionGroup> {
         let group = SimpleActionGroup::new();
         for a in song.make_artist_actions(self.dispatcher.box_clone(), None) {
             group.add_action(&a);
@@ -274,9 +272,7 @@ impl PlaylistModel for PlaylistDetailsModel {
         Some(group.upcast())
     }
 
-    fn menu_for(&self, id: &str) -> Option<gio::MenuModel> {
-        let song = PlaylistModel::song_list_model(self).get(id)?;
-        let song = song.description();
+    fn menu_for(&self, song: &SongDescription) -> Option<gio::MenuModel> {
         let menu = gio::Menu::new();
         menu.append(Some(&*labels::VIEW_ALBUM), Some("song.view_album"));
         for artist in song.artists.iter() {

--- a/src/app/components/pages/now_playing/model.rs
+++ b/src/app/components/pages/now_playing/model.rs
@@ -228,10 +228,7 @@ impl PlaylistModel for NowPlayingModel {
         self.base.toggle_song_like(&songs, id);
     }
 
-    fn actions_for(&self, id: &str) -> Option<gio::ActionGroup> {
-        let queue = self.queue();
-        let song = queue.songs().get(id)?;
-        let song = song.description();
+    fn actions_for(&self, song: &SongDescription) -> Option<gio::ActionGroup> {
         let group = SimpleActionGroup::new();
         for a in song.make_artist_actions(self.dispatcher.box_clone(), None) {
             group.add_action(&a);
@@ -242,10 +239,7 @@ impl PlaylistModel for NowPlayingModel {
         Some(group.upcast())
     }
 
-    fn menu_for(&self, id: &str) -> Option<gio::MenuModel> {
-        let queue = self.queue();
-        let song = queue.songs().get(id)?;
-        let song = song.description();
+    fn menu_for(&self, song: &SongDescription) -> Option<gio::MenuModel> {
         let menu = gio::Menu::new();
         menu.append(Some(&*labels::VIEW_ALBUM), Some("song.view_album"));
         for artist in song.artists.iter() {

--- a/src/app/components/pages/saved_tracks/model.rs
+++ b/src/app/components/pages/saved_tracks/model.rs
@@ -168,9 +168,7 @@ impl PlaylistModel for SavedTracksModel {
         }
     }
 
-    fn actions_for(&self, id: &str) -> Option<gio::ActionGroup> {
-        let song = PlaylistModel::song_list_model(self).get(id)?;
-        let song = song.description();
+    fn actions_for(&self, song: &SongDescription) -> Option<gio::ActionGroup> {
         let group = SimpleActionGroup::new();
         for a in song.make_artist_actions(self.dispatcher.box_clone(), None) {
             group.add_action(&a);
@@ -180,9 +178,7 @@ impl PlaylistModel for SavedTracksModel {
         Some(group.upcast())
     }
 
-    fn menu_for(&self, id: &str) -> Option<gio::MenuModel> {
-        let song = PlaylistModel::song_list_model(self).get(id)?;
-        let song = song.description();
+    fn menu_for(&self, song: &SongDescription) -> Option<gio::MenuModel> {
         let menu = gio::Menu::new();
         menu.append(Some(&*labels::VIEW_ALBUM), Some("song.view_album"));
         for artist in song.artists.iter() {

--- a/src/app/components/widgets/playlist/playlist.rs
+++ b/src/app/components/widgets/playlist/playlist.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use crate::app::components::utils::{ancestor, AnimatorDefault};
 use crate::app::components::{Component, EventListener, SongWidget};
-use crate::app::models::{SongListModel, SongModel, SongState};
+use crate::app::models::{SongDescription, SongListModel, SongModel, SongState};
 use crate::app::state::{BrowserEvent, PlaybackEvent, SelectionEvent, SelectionState};
 use crate::app::{AppEvent, Worker};
 
@@ -26,10 +26,10 @@ pub trait PlaylistModel {
         true
     }
 
-    fn actions_for(&self, _id: &str) -> Option<gio::ActionGroup> {
+    fn actions_for(&self, _song: &SongDescription) -> Option<gio::ActionGroup> {
         None
     }
-    fn menu_for(&self, _id: &str) -> Option<gio::MenuModel> {
+    fn menu_for(&self, _song: &SongDescription) -> Option<gio::MenuModel> {
         None
     }
 
@@ -116,16 +116,27 @@ where
             move |_, item| {
                 let item = item.downcast_ref::<gtk::ListItem>().unwrap();
                 let song_model = item.item().unwrap().downcast::<SongModel>().unwrap();
-                song_model.set_state(model.song_state(&song_model.get_id()));
 
+                // IMPORTANT: this callback must NOT read AppState (e.g. via
+                // model.song_state / current_song_id / selection). It runs while
+                // GTK emits items_changed, which we now emit synchronously from
+                // inside AppState's borrow_mut. Reading AppState here would panic
+                // (already-borrowed) and reintroduce the crash class this design
+                // avoids.
+                //
+                // The widget's appearance is driven entirely by the SongModel's
+                // own GObject properties (playing/selected/liked), which are
+                // seeded/updated out-of-band by Playlist::update_list. actions
+                // and menus are built from the SongModel's SongDescription, not
+                // from a lookup into AppState.
                 let widget = item.child().unwrap().downcast::<SongWidget>().unwrap();
                 widget.bind(&song_model, worker.clone(), model.show_song_covers());
 
-                let id = song_model.get_id();
-                widget.set_actions(model.actions_for(&id).as_ref());
-                widget.set_menu(model.menu_for(&id).as_ref());
+                let song = song_model.description();
+                widget.set_actions(model.actions_for(&song).as_ref());
+                widget.set_menu(model.menu_for(&song).as_ref());
 
-                let like_id = id.clone();
+                let like_id = song.id.clone();
                 widget.connect_like(clone!(
                     #[weak]
                     model,
@@ -175,11 +186,22 @@ where
         ));
         listview.add_controller(press_gesture);
 
-        Self {
+        let playlist = Self {
             animator: AnimatorDefault::ease_in_out_animator(),
             listview,
             model,
-        }
+        };
+
+        // Seed the state (playing/selected/liked) of any items already present
+        // in the model. This runs during component construction, which happens
+        // outside AppState's borrow_mut, so reading AppState here is safe. It is
+        // required because the bind callback no longer pulls state from AppState;
+        // without this, pre-existing rows (e.g. the current track in the queue
+        // when opening the Now Playing page) would render with default state.
+        // Note: no autoscroll here — construction should not move the viewport.
+        playlist.seed_song_states();
+
+        playlist
     }
 
     fn autoscroll_to_playing(&self, index: usize) {
@@ -211,6 +233,25 @@ where
         }
     }
 
+    /// Refresh every loaded song's presentation state (playing/selected/liked)
+    /// from the model. Has NO side effects on scroll position.
+    ///
+    /// Use this for content-change events (initial load, pagination, queue
+    /// changes). Autoscrolling on those events is wrong and, on multi-section
+    /// pages (e.g. the artist page, where a playlist and a card list share one
+    /// scrolled window), drives a feedback loop: autoscroll -> bottom edge ->
+    /// card-list load_more -> content event -> autoscroll ... which hammers
+    /// pagination and can surface duplicate cards.
+    fn seed_song_states(&self) {
+        self.model.song_list_model().for_each(|_, model_song| {
+            let state = self.model.song_state(&model_song.get_id());
+            model_song.set_state(state);
+        });
+    }
+
+    /// Like `seed_song_states`, but additionally autoscrolls to the currently
+    /// playing track. Only appropriate for events where following the playing
+    /// track is the intended behavior (e.g. TrackChanged).
     fn update_list(&self) {
         let autoscroll_to_playing = self.model.autoscroll_to_playing();
         let is_selection_enabled = self.model.is_selection_enabled();
@@ -282,6 +323,27 @@ where
             }
             AppEvent::BrowserEvent(BrowserEvent::SavedTracksUpdated) => {
                 self.update_list();
+            }
+            // Content-change events: the backing song list gained or lost items
+            // (initial load, pagination, queue changes, removals). Re-seed each
+            // SongModel's state because the bind callback no longer pulls it from
+            // AppState. This runs post-dispatch (borrow released), so reading
+            // AppState is safe. Crucially we seed WITHOUT autoscrolling — these
+            // events fire during pagination, and autoscrolling here would drive a
+            // scroll -> load_more -> content-event feedback loop.
+            AppEvent::PlaybackEvent(PlaybackEvent::PlaylistChanged) => {
+                self.seed_song_states();
+            }
+            AppEvent::BrowserEvent(
+                BrowserEvent::AlbumDetailsLoaded(_)
+                | BrowserEvent::AlbumTracksAppended(_)
+                | BrowserEvent::PlaylistDetailsLoaded(_)
+                | BrowserEvent::PlaylistTracksAppended(_)
+                | BrowserEvent::PlaylistTracksRemoved(_)
+                | BrowserEvent::ArtistDetailsUpdated(_)
+                | BrowserEvent::UserDetailsUpdated(_),
+            ) => {
+                self.seed_song_states();
             }
             _ => {}
         }

--- a/src/app/models/songs/song_list_model.rs
+++ b/src/app/models/songs/song_list_model.rs
@@ -77,18 +77,22 @@ impl SongListModel {
     }
 
     fn notify_changes(&self, changes: impl IntoIterator<Item = ListRangeUpdate> + 'static) {
-        // Eh, not great but that works
+        // items_changed MUST be emitted synchronously, immediately after the
+        // backing SongList mutates. GTK's ListModel contract requires that the
+        // model never be observable in a state where n_items() disagrees with
+        // what GTK's item trackers expect. Deferring this signal (e.g. via
+        // idle_add) let the frame clock process crossing/redraw events against a
+        // torn model, causing a SIGSEGV in gtk_list_item_manager_ensure_items.
+        //
+        // Emitting synchronously is safe here even though we are inside
+        // AppState's borrow_mut, because the ListView bind callback is now
+        // self-contained: it reads only the SongModel handed to it by GTK and
+        // never calls back into AppModel::get_state(). See Playlist::new.
         if cfg!(not(test)) {
-            glib::source::idle_add_local_once(clone!(
-                #[weak(rename_to = s)]
-                self,
-                move || {
-                    for ListRangeUpdate(a, b, c) in changes.into_iter() {
-                        debug!("pos {}, removed {}, added {}", a, b, c);
-                        s.items_changed(a as u32, b as u32, c as u32);
-                    }
-                }
-            ));
+            for ListRangeUpdate(a, b, c) in changes.into_iter() {
+                debug!("pos {}, removed {}, added {}", a, b, c);
+                self.items_changed(a as u32, b as u32, c as u32);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes a crash class (SIGSEGV in gtk_list_item_manager_ensure_items) and a BorrowMutError panic caused by the ListView bind callback reading AppState while it was already mutably borrowed.

### Problem

The SongListModel deferred items_changed signals via idle_add_local, which allowed GTK's frame clock to process events against a torn model (where n_items() disagreed with GTK'sinternal trackers). Additionally, the bind callback in Playlist::new called model.song_state() — which reads AppState — during items_changed emission, triggering a re-entrant borrow panic.

### Changes

- Synchronous items_changed emission (song_list_model.rs): Removed the idle_add_local deferral. Signals are now emitted immediately after the backing SongList mutates, satisfying GTK's ListModel contract.
- Self-contained bind callback (playlist.rs): The bind callback no longer reads AppState. It builds actions/menus from the SongModel's own SongDescription instead of looking up state by ID.
- PlaylistModel trait signature change: actions_for and menu_for now take &SongDescription instead of &str (song ID), removing the need for callers to look up songs from state during binding.
- seed_song_states() method: A new method that refreshes every loaded song's presentation state (playing/selected/liked) from the model. Called at playlist construction and on content-change events (post-dispatch, when AppState is safely accessible).
- Content-change event handling: Added handlers for PlaylistChanged, AlbumDetailsLoaded, PlaylistDetailsLoaded, ArtistDetailsUpdated, etc. that call seed_song_states() without autoscrolling — preventing a scroll → load_more → content-event feedback loop on paginated/multi-section pages.