### PR TITLE
fix volume scroll crash by debouncing dispatch, adding idempotency guard, and clamping MPRIS input

### DIFF
--- a/src/app/components/shell/playback/playback_widget.rs
+++ b/src/app/components/shell/playback/playback_widget.rs
@@ -290,9 +290,17 @@ impl PlaybackWidget {
     where
         F: Fn(f64) + Clone + 'static,
     {
+        let debouncer = Debouncer::new();
         let widget = self.imp();
-        widget
-            .volume_slider
-            .connect_value_changed(move |scale| f(scale.value()));
+        widget.volume_slider.connect_value_changed(move |scale| {
+            // Debounce dispatch: a single mouse-wheel flick emits a burst of
+            // high-resolution scroll deltas, each firing `value_changed`.
+            // Without this, every delta would fan out to the mixer, the Web
+            // API, dconf and an MPRIS `PropertiesChanged` D-Bus signal, which
+            // can flood GNOME Shell's media controls and hang the session.
+            let value = scale.value();
+            let f = f.clone();
+            debouncer.debounce(100, move || f(value));
+        });
     }
 }

--- a/src/app/state/playback_state.rs
+++ b/src/app/state/playback_state.rs
@@ -19,6 +19,9 @@ pub struct PlaybackState {
     repeat: RepeatMode,
     is_playing: bool,
     is_shuffled: bool,
+    // Last volume that was applied (0.0..=1.0). Initialised to a sentinel
+    // outside the valid range so the first `SetVolume` always propagates.
+    volume: f64,
 }
 
 // Most mutatings methods shouldn't be pub
@@ -284,6 +287,7 @@ impl Default for PlaybackState {
             repeat: RepeatMode::None,
             is_playing: false,
             is_shuffled: false,
+            volume: -1.0,
         }
     }
 }
@@ -472,7 +476,17 @@ impl UpdatableState for PlaybackState {
                 vec![PlaybackEvent::SeekSynced(pos)]
             }
             PlaybackAction::SetVolume(volume) => {
-                vec![PlaybackEvent::VolumeSet(volume)]
+                // Idempotency guard: only emit (and thus touch dconf, the
+                // mixer, the Web API and MPRIS/D-Bus) when the volume actually
+                // changes. Rapid volume input (e.g. mouse-wheel scrolling the
+                // slider) would otherwise fan out a storm of `VolumeSet` events
+                // and MPRIS `PropertiesChanged` signals.
+                if self.volume == volume {
+                    vec![]
+                } else {
+                    self.volume = volume;
+                    vec![PlaybackEvent::VolumeSet(volume)]
+                }
             }
 
             PlaybackAction::SetAvailableDevices(list) => {

--- a/src/dbus/mpris.rs
+++ b/src/dbus/mpris.rs
@@ -341,7 +341,7 @@ impl RiffMprisPlayer {
         // also, we don't support volume higher than 100% at the moment.
         let volume = value.clamp(0.0, 1.0);
         self.sender
-            .unbounded_send(PlaybackAction::SetVolume(value).into())
+            .unbounded_send(PlaybackAction::SetVolume(volume).into())
             .map_err(|_| Error::Failed("Could not send action".to_string()))?;
         Ok(())
     }


### PR DESCRIPTION
Scrolling the volume slider with the mouse wheel could crash the entire GNOME desktop session. A single wheel flick produced dozens to hundreds of value_changed events, each fanning out unthrottled to the librespot mixer, the Spotify Web API, a dconf write, and an MPRIS PropertiesChanged D-Bus signal aimed at GNOME Shell's built-in media controller.

### Changes

1. Debounce volume dispatch (playback_widget.rs) — wraps connect_volume_changed in a 100 ms Debouncer (same utility used by seek), collapsing scroll bursts into a single dispatch.
2. Idempotency guard (playback_state.rs) — SetVolume now tracks the last applied volume and only emits VolumeSet when the value actually changes, preventing redundant fan-out and breaking potential MPRIS feedback loops.
3. MPRIS clamp bug (mpris.rs) — set_volume computed value.clamp(0.0, 1.0) into a local but then dispatched the raw unclamped value. Now dispatches the clamped result.

### Related
https://github.com/Diegovsky/riff/issues/66