### PR TITLE
Added spotify link detection

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -9,6 +9,7 @@ src/app/models/card_enums.rs
 src/app/components/mod.rs
 src/app/components/navigation/factory.rs
 src/app/components/notification/mod.rs
+src/app/components/shell/clipboard_import/mod.rs
 src/app/components/pages/details_artist/widget.rs
 src/app/components/pages/details_playlist/model.rs
 src/app/components/pages/details_user/model.rs

--- a/src/api/api_models.rs
+++ b/src/api/api_models.rs
@@ -571,6 +571,20 @@ impl TryFrom<Album> for SongBatch {
     }
 }
 
+impl From<TrackItem> for SongDescription {
+    /// Convert a single fetched track (e.g. from `GET /v1/tracks/{id}`) into the
+    /// domain `SongDescription`. The track carries its own album, so the
+    /// resulting song always has a valid `album` reference.
+    fn from(track: TrackItem) -> Self {
+        let batch: SongBatch = Page::new(vec![track]).into();
+        batch
+            .songs
+            .into_iter()
+            .next()
+            .expect("a fetched track always yields exactly one song")
+    }
+}
+
 impl From<FullAlbum> for AlbumFullDescription {
     fn from(full_album: FullAlbum) -> Self {
         let description = full_album.album.into();
@@ -751,5 +765,29 @@ mod tests {
             query.into_query_string(),
             "type=playlist&q=daft+punk&offset=40&limit=20&market=from_token"
         );
+    }
+
+    #[test]
+    fn test_track_item_into_song_description() {
+        // Shape returned by GET /v1/tracks/{id}: a track with a nested album.
+        let track = r#"{
+            "id": "track123",
+            "uri": "spotify:track:track123",
+            "name": "Some Song",
+            "duration_ms": 210000,
+            "track_number": 3,
+            "artists": [{"id": "artist1", "name": "Artist"}],
+            "album": {
+                "id": "album456",
+                "name": "Some Album",
+                "artists": [{"id": "artist1", "name": "Artist"}],
+                "images": [{"height": 64, "url": "http://img", "width": 64}]
+            }
+        }"#;
+        let deserialized: TrackItem = serde_json::from_str(track).unwrap();
+        let song: SongDescription = deserialized.into();
+        assert_eq!(song.id, "track123");
+        assert_eq!(song.album.id, "album456");
+        assert_eq!(song.title, "Some Song");
     }
 }

--- a/src/api/cached_client.rs
+++ b/src/api/cached_client.rs
@@ -44,6 +44,8 @@ pub trait SpotifyApiClient {
 
     fn get_album(&self, id: &str) -> BoxFuture<SpotifyResult<AlbumFullDescription>>;
 
+    fn get_track(&self, id: &str) -> BoxFuture<SpotifyResult<SongDescription>>;
+
     fn get_album_tracks(
         &self,
         id: &str,
@@ -181,6 +183,7 @@ enum RiffCacheKey<'a> {
     Album(&'a str),
     AlbumLiked(&'a str),
     AlbumTracks(&'a str, usize, usize),
+    Track(&'a str),
     Playlist(&'a str),
     PlaylistTracks(&'a str, usize, usize),
     ArtistAlbums(&'a str, usize, usize),
@@ -200,6 +203,7 @@ impl RiffCacheKey<'_> {
             Self::AlbumTracks(id, offset, limit) => {
                 format!("album_item_{id}_{offset}_{limit}.json")
             }
+            Self::Track(id) => format!("track_{id}.json"),
             Self::AlbumLiked(id) => format!("album_liked_{id}.json"),
             Self::Playlist(id) => format!("playlist_{id}.json"),
             Self::PlaylistTracks(id, offset, limit) => {
@@ -530,6 +534,20 @@ impl SpotifyApiClient for CachedSpotifyClient {
             album.description.is_liked = liked?[0];
 
             Ok(album)
+        })
+    }
+
+    fn get_track(&self, id: &str) -> BoxFuture<SpotifyResult<SongDescription>> {
+        let id = id.to_owned();
+
+        Box::pin(async move {
+            let track: TrackItem = self
+                .cache_get_or_write(RiffCacheKey::Track(&id), None, |etag| {
+                    self.client.get_track(&id).etag(etag).send()
+                })
+                .await?;
+
+            Ok(track.into())
         })
     }
 

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -368,6 +368,15 @@ impl SpotifyClient {
             .uri(format!("/v1/albums/{id}"), None)
     }
 
+    pub(crate) fn get_track(&self, id: &str) -> SpotifyRequest<'_, (), TrackItem> {
+        let query = make_query_params()
+            .append_pair("market", "from_token")
+            .finish();
+        self.request()
+            .method(Method::GET)
+            .uri(format!("/v1/tracks/{id}"), Some(&query))
+    }
+
     pub(crate) fn get_album_tracks(
         &self,
         id: &str,

--- a/src/app/components/clipboard_link.rs
+++ b/src/app/components/clipboard_link.rs
@@ -1,0 +1,63 @@
+//! Tracks the last Spotify link that Riff itself wrote to the clipboard.
+//!
+//! Riff has "Copy link" actions that place `https://open.spotify.com/...` URLs
+//! on the clipboard. The clipboard watcher should not turn around and offer to
+//! open a link the user just copied *from* Riff, so those actions record the
+//! link here and the watcher checks against it.
+//!
+//! GTK runs entirely on the main-context thread, so a `thread_local!` is a
+//! simple and correct place to keep this shared state.
+
+use std::cell::RefCell;
+
+use gdk::prelude::*;
+
+thread_local! {
+    static LAST_APP_COPIED_LINK: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// Record a link that Riff just wrote to the clipboard.
+pub fn remember_app_copied_link(link: &str) {
+    let link = link.trim().to_string();
+    LAST_APP_COPIED_LINK.with(|last| *last.borrow_mut() = Some(link));
+}
+
+/// Copy a link to the clipboard and record it as app-copied, so the clipboard
+/// watcher won't offer to open the link the user just copied from Riff.
+pub fn copy_link_to_clipboard(link: &str) {
+    let clipboard = gdk::Display::default().unwrap().clipboard();
+    clipboard
+        .set_content(Some(&gdk::ContentProvider::for_value(&link.to_value())))
+        .expect("Failed to set clipboard content");
+    remember_app_copied_link(link);
+}
+
+/// Whether the given clipboard text is (still) the last link Riff copied.
+pub fn is_app_copied_link(text: &str) -> bool {
+    let text = text.trim();
+    LAST_APP_COPIED_LINK.with(|last| last.borrow().as_deref() == Some(text))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_remember_and_match() {
+        let link = "https://open.spotify.com/track/remember_and_match";
+        remember_app_copied_link(link);
+        assert!(is_app_copied_link(link));
+        // Matching is whitespace-insensitive on the incoming text.
+        assert!(is_app_copied_link(
+            "  https://open.spotify.com/track/remember_and_match \n"
+        ));
+    }
+
+    #[test]
+    fn test_non_matching_link() {
+        remember_app_copied_link("https://open.spotify.com/track/aaa_non_matching");
+        assert!(!is_app_copied_link(
+            "https://open.spotify.com/track/bbb_non_matching"
+        ));
+    }
+}

--- a/src/app/components/mod.rs
+++ b/src/app/components/mod.rs
@@ -32,6 +32,9 @@ pub mod utils;
 
 pub mod labels;
 
+pub mod clipboard_link;
+pub use clipboard_link::{copy_link_to_clipboard, is_app_copied_link};
+
 // without this the builder doesn't seen to know about the custom widgets
 pub fn expose_custom_widgets() {
     shell::playback::expose_widgets();

--- a/src/app/components/pages/details_album/model.rs
+++ b/src/app/components/pages/details_album/model.rs
@@ -168,6 +168,14 @@ impl PageModel for DetailsModel {
         true
     }
 
+    fn has_share_button(&self) -> bool {
+        true
+    }
+
+    fn on_share_clicked(&self) {
+        self.share_link(&format!("https://open.spotify.com/album/{}", self.id));
+    }
+
     fn has_subtitle_link(&self) -> bool {
         true
     }

--- a/src/app/components/pages/details_artist/model.rs
+++ b/src/app/components/pages/details_artist/model.rs
@@ -161,6 +161,14 @@ impl PageModel for ArtistDetailsModel {
     fn should_refresh_details(&self, event: &AppEvent) -> bool {
         matches!(event, AppEvent::BrowserEvent(BrowserEvent::ArtistDetailsUpdated(id)) if id == &self.id)
     }
+
+    fn has_share_button(&self) -> bool {
+        true
+    }
+
+    fn on_share_clicked(&self) {
+        self.share_link(&format!("https://open.spotify.com/artist/{}", self.id));
+    }
 }
 
 impl CardListModel for ArtistDetailsModel {

--- a/src/app/components/pages/details_playlist/model.rs
+++ b/src/app/components/pages/details_playlist/model.rs
@@ -213,6 +213,14 @@ impl PageModel for PlaylistDetailsModel {
         }
     }
 
+    fn has_share_button(&self) -> bool {
+        true
+    }
+
+    fn on_share_clicked(&self) {
+        self.share_link(&format!("https://open.spotify.com/playlist/{}", self.id));
+    }
+
     fn should_refresh_details(&self, event: &AppEvent) -> bool {
         matches!(event, AppEvent::BrowserEvent(BrowserEvent::PlaylistDetailsLoaded(id)) if id == &self.id)
     }

--- a/src/app/components/pages/details_user/model.rs
+++ b/src/app/components/pages/details_user/model.rs
@@ -112,6 +112,14 @@ impl PageModel for UserDetailsModel {
     fn should_refresh_details(&self, event: &AppEvent) -> bool {
         matches!(event, AppEvent::BrowserEvent(BrowserEvent::UserDetailsUpdated(id)) if id == &self.id)
     }
+
+    fn has_share_button(&self) -> bool {
+        true
+    }
+
+    fn on_share_clicked(&self) {
+        self.share_link(&format!("https://open.spotify.com/user/{}", self.id));
+    }
 }
 
 impl CardListModel for UserDetailsModel {

--- a/src/app/components/pages/now_playing/model.rs
+++ b/src/app/components/pages/now_playing/model.rs
@@ -163,6 +163,17 @@ impl PageModel for NowPlayingModel {
         }
     }
 
+    fn has_share_button(&self) -> bool {
+        true
+    }
+
+    fn on_share_clicked(&self) {
+        if let Some(song) = self.current_song() {
+            self.base
+                .share_link(&format!("https://open.spotify.com/track/{}", song.id));
+        }
+    }
+
     fn should_refresh_details(&self, event: &AppEvent) -> bool {
         matches!(
             event,

--- a/src/app/components/shell/clipboard_import/mod.rs
+++ b/src/app/components/shell/clipboard_import/mod.rs
@@ -1,0 +1,208 @@
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use gettextrs::gettext;
+use gtk::prelude::*;
+use libadwaita::prelude::*;
+
+use crate::app::components::{is_app_copied_link, EventListener};
+use crate::app::state::SpotifyLink;
+use crate::app::{ActionDispatcher, AppAction, AppModel};
+
+/// Watches the system clipboard and, when the Riff window is focused, offers to
+/// open a Spotify link the user copied from somewhere other than Riff.
+pub struct ClipboardImport {
+    // Kept alive for the lifetime of the component; the window signal holds a
+    // weak reference to it.
+    _watcher: Rc<ClipboardWatcher>,
+}
+
+impl ClipboardImport {
+    pub fn new(
+        window: libadwaita::ApplicationWindow,
+        dispatcher: Box<dyn ActionDispatcher>,
+        app_model: Rc<AppModel>,
+    ) -> Self {
+        let watcher = Rc::new(ClipboardWatcher {
+            window: window.clone(),
+            dispatcher,
+            app_model,
+            dismissed: RefCell::new(None),
+            dialog_open: Cell::new(false),
+        });
+
+        // Check the clipboard whenever the window gains focus. A weak reference
+        // avoids a reference cycle between the window and the watcher.
+        let watcher_weak = Rc::downgrade(&watcher);
+        window.connect_is_active_notify(move |window| {
+            if !window.is_active() {
+                return;
+            }
+            if let Some(watcher) = watcher_weak.upgrade() {
+                watcher.check_clipboard();
+            }
+        });
+
+        Self { _watcher: watcher }
+    }
+}
+
+impl EventListener for ClipboardImport {}
+
+struct ClipboardWatcher {
+    window: libadwaita::ApplicationWindow,
+    dispatcher: Box<dyn ActionDispatcher>,
+    app_model: Rc<AppModel>,
+    // The last link the user chose not to open (or already acted on). Prevents
+    // re-prompting for the same link every time the window regains focus.
+    dismissed: RefCell<Option<String>>,
+    dialog_open: Cell<bool>,
+}
+
+impl ClipboardWatcher {
+    fn check_clipboard(self: &Rc<Self>) {
+        if self.dialog_open.get() {
+            return;
+        }
+
+        let clipboard = self.window.clipboard();
+        let this = Rc::clone(self);
+        clipboard.read_text_async(gio::Cancellable::NONE, move |result| {
+            if let Ok(Some(text)) = result {
+                this.handle_text(text.to_string());
+            }
+        });
+    }
+
+    fn handle_text(self: &Rc<Self>, text: String) {
+        let dismissed = self.dismissed.borrow().clone();
+        let decision = decide(&text, is_app_copied_link(&text), dismissed.as_deref());
+        if let Some(link) = decision {
+            debug!("clipboard contains a Spotify {} link", link.kind_label());
+            self.show_dialog(text, link);
+        }
+    }
+
+    fn show_dialog(self: &Rc<Self>, text: String, link: SpotifyLink) {
+        if self.dialog_open.replace(true) {
+            return;
+        }
+
+        let heading = gettext("Open Spotify link?");
+        let body = match &link {
+            // translators: shown when an album link is found in the clipboard.
+            SpotifyLink::Album(_) => {
+                gettext("There's a Spotify album link in your clipboard. Open it in Riff?")
+            }
+            // translators: shown when an artist link is found in the clipboard.
+            SpotifyLink::Artist(_) => {
+                gettext("There's a Spotify artist link in your clipboard. Open it in Riff?")
+            }
+            // translators: shown when a playlist link is found in the clipboard.
+            SpotifyLink::Playlist(_) => {
+                gettext("There's a Spotify playlist link in your clipboard. Open it in Riff?")
+            }
+            // translators: shown when a user profile link is found in the clipboard.
+            SpotifyLink::User(_) => {
+                gettext("There's a Spotify profile link in your clipboard. Open it in Riff?")
+            }
+            // translators: shown when a song/track link is found in the clipboard.
+            SpotifyLink::Track(_) => {
+                gettext("There's a Spotify song link in your clipboard. Open it in Riff?")
+            }
+        };
+
+        let dialog = libadwaita::AlertDialog::new(Some(&heading), Some(&body));
+        dialog.add_response("cancel", &gettext("Cancel"));
+        dialog.add_response("open", &gettext("Open"));
+        dialog.set_response_appearance("open", libadwaita::ResponseAppearance::Suggested);
+        dialog.set_default_response(Some("open"));
+        dialog.set_close_response("cancel");
+
+        let this = Rc::clone(self);
+        dialog.choose(&self.window, gio::Cancellable::NONE, move |response| {
+            this.dialog_open.set(false);
+            // Regardless of the choice, remember this link so we don't
+            // prompt for it again until the clipboard changes.
+            this.dismissed.replace(Some(text.trim().to_string()));
+            if response.as_str() == "open" {
+                this.open_link(link);
+            }
+        });
+    }
+
+    fn open_link(&self, link: SpotifyLink) {
+        match link {
+            SpotifyLink::Album(id) => self.dispatcher.dispatch(AppAction::ViewAlbum(id)),
+            SpotifyLink::Artist(id) => self.dispatcher.dispatch(AppAction::ViewArtist(id)),
+            SpotifyLink::Playlist(id) => self.dispatcher.dispatch(AppAction::ViewPlaylist(id)),
+            SpotifyLink::User(id) => self.dispatcher.dispatch(AppAction::ViewUser(id)),
+            SpotifyLink::Track(id) => {
+                // No track detail screen exists: resolve the track's album and
+                // open that instead.
+                let api = self.app_model.get_spotify();
+                self.dispatcher
+                    .call_spotify_and_dispatch(move || async move {
+                        api.get_track(&id)
+                            .await
+                            .map(|song| AppAction::ViewAlbum(song.album.id))
+                    });
+            }
+        }
+    }
+}
+
+/// Pure decision logic: given the clipboard text, whether it matches a link
+/// Riff itself copied, and the last dismissed link, return the link to prompt
+/// for (if any).
+fn decide(text: &str, is_app_copied: bool, dismissed: Option<&str>) -> Option<SpotifyLink> {
+    let link = SpotifyLink::parse(text)?;
+    if is_app_copied {
+        return None;
+    }
+    if dismissed == Some(text.trim()) {
+        return None;
+    }
+    Some(link)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decide_prompts_for_external_link() {
+        let text = "https://open.spotify.com/album/abc";
+        assert_eq!(
+            decide(text, false, None),
+            Some(SpotifyLink::Album("abc".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_decide_skips_app_copied_link() {
+        let text = "https://open.spotify.com/track/abc";
+        assert_eq!(decide(text, true, None), None);
+    }
+
+    #[test]
+    fn test_decide_skips_dismissed_link() {
+        let text = "https://open.spotify.com/track/abc";
+        assert_eq!(decide(text, false, Some(text)), None);
+    }
+
+    #[test]
+    fn test_decide_skips_non_spotify_text() {
+        assert_eq!(decide("just some text", false, None), None);
+        assert_eq!(decide("https://example.com", false, None), None);
+    }
+
+    #[test]
+    fn test_decide_prompts_when_dismissed_is_different() {
+        let text = "https://open.spotify.com/playlist/new";
+        assert_eq!(
+            decide(text, false, Some("https://open.spotify.com/playlist/old")),
+            Some(SpotifyLink::Playlist("new".to_string()))
+        );
+    }
+}

--- a/src/app/components/shell/mod.rs
+++ b/src/app/components/shell/mod.rs
@@ -17,6 +17,9 @@ pub use notification::*;
 pub mod window;
 pub use window::*;
 
+pub mod clipboard_import;
+pub use clipboard_import::*;
+
 pub mod headerbar;
 pub use headerbar::*;
 

--- a/src/app/components/shell/sidebar/playlist_actions.rs
+++ b/src/app/components/shell/sidebar/playlist_actions.rs
@@ -36,10 +36,7 @@ fn make_copy_link_action(id: &str) -> gio::SimpleAction {
     let id = id.to_owned();
     action.connect_activate(move |_, _| {
         let link = format!("https://open.spotify.com/playlist/{id}");
-        let clipboard = gdk::Display::default().unwrap().clipboard();
-        clipboard
-            .set_content(Some(&gdk::ContentProvider::for_value(&link.to_value())))
-            .expect("Failed to set clipboard content");
+        crate::app::components::copy_link_to_clipboard(&link);
     });
     action
 }

--- a/src/app/components/widgets/details_page/component.rs
+++ b/src/app/components/widgets/details_page/component.rs
@@ -216,6 +216,14 @@ impl<M: PageModel + 'static> DetailsPageComponent<M> {
             ));
         }
 
+        if self.model.has_share_button() {
+            self.page.header().connect_share(clone!(
+                #[weak(rename_to = m)]
+                self.model,
+                move || m.on_share_clicked()
+            ));
+        }
+
         if self.model.has_subtitle_link() {
             self.page.header().connect_subtitle_clicked(clone!(
                 #[weak(rename_to = m)]

--- a/src/app/components/widgets/details_page/header.blp
+++ b/src/app/components/widgets/details_page/header.blp
@@ -146,6 +146,19 @@ template $DetailsHeaderWidget : Box {
             ]
           }
 
+          Button share_button {
+            icon-name: "folder-publicshare-symbolic";
+            halign: center;
+            valign: center;
+            visible: false;
+            tooltip-text: _("Copy link");
+
+            styles [
+              "circular",
+              "share__button",
+            ]
+          }
+
           Box {
             hexpand: true;
           }

--- a/src/app/components/widgets/details_page/header.rs
+++ b/src/app/components/widgets/details_page/header.rs
@@ -48,6 +48,9 @@ mod imp {
         pub like_button: TemplateChild<gtk::Button>,
 
         #[template_child]
+        pub share_button: TemplateChild<gtk::Button>,
+
+        #[template_child]
         pub info_button: TemplateChild<gtk::Button>,
 
         #[template_child]
@@ -239,6 +242,12 @@ impl DetailsHeader {
     pub fn connect_info<F: Fn() + 'static>(&self, f: F) {
         self.widget.imp().info_button.set_visible(true);
         self.widget.imp().info_button.connect_clicked(move |_| f());
+    }
+
+    /// Connect a handler to the share button. Also makes the button visible.
+    pub fn connect_share<F: Fn() + 'static>(&self, f: F) {
+        self.widget.imp().share_button.set_visible(true);
+        self.widget.imp().share_button.connect_clicked(move |_| f());
     }
 
     /// Connect a handler to the edit button. Also makes the button visible.

--- a/src/app/components/widgets/details_page/model.rs
+++ b/src/app/components/widgets/details_page/model.rs
@@ -102,6 +102,15 @@ impl DetailsPageModel {
         &*self.dispatcher
     }
 
+    /// Copy a shareable link to the clipboard and show a confirmation toast.
+    pub fn share_link(&self, link: &str) {
+        crate::app::components::copy_link_to_clipboard(link);
+        self.dispatcher
+            .dispatch(AppAction::ShowNotification(gettextrs::gettext(
+                "Link copied to clipboard",
+            )));
+    }
+
     // Playback state helpers
 
     pub fn is_paused(&self) -> bool {
@@ -298,6 +307,7 @@ mod tests {
     impl SpotifyApiClient for MockApi {
         stub_api_method!(get_artist(_id: &str) -> ArtistDescription);
         stub_api_method!(get_album(_id: &str) -> AlbumFullDescription);
+        stub_api_method!(get_track(_id: &str) -> SongDescription);
         stub_api_method!(get_album_tracks(_id: &str, _offset: usize, _limit: usize) -> SongBatch);
         stub_api_method!(get_playlist(_id: &str) -> PlaylistDescription);
         stub_api_method!(get_playlist_tracks(_id: &str, _offset: usize, _limit: usize) -> SongBatch);

--- a/src/app/components/widgets/details_page/style.css
+++ b/src/app/components/widgets/details_page/style.css
@@ -53,7 +53,7 @@
   animation: skeleton-pulse 1.5s ease-in-out infinite;
 }
 
-.details-page-content .details-header .circular:not(.play__button):not(.like__button):not(.shuffle__button):not(.info__button) {
+.details-page-content .details-header .circular:not(.play__button):not(.like__button):not(.shuffle__button):not(.info__button):not(.share__button) {
   background-color: @skeleton_color;
   color: transparent;
   opacity: 0;
@@ -63,6 +63,7 @@
 .details-page-content:not(.details-page--loaded) .details-header .play__button,
 .details-page-content:not(.details-page--loaded) .details-header .shuffle__button,
 .details-page-content:not(.details-page--loaded) .details-header .like__button,
+.details-page-content:not(.details-page--loaded) .details-header .share__button,
 .details-page-content:not(.details-page--loaded) .details-header .edit__button {
   background-color: @skeleton_color;
   color: transparent;
@@ -101,7 +102,7 @@
   min-width: unset;
 }
 
-.details-page--loaded .details-header .circular:not(.play__button):not(.like__button):not(.shuffle__button):not(.info__button) {
+.details-page--loaded .details-header .circular:not(.play__button):not(.like__button):not(.shuffle__button):not(.info__button):not(.share__button) {
   animation: none;
   background-color: transparent;
   color: inherit;

--- a/src/app/components/widgets/details_page/traits.rs
+++ b/src/app/components/widgets/details_page/traits.rs
@@ -88,6 +88,13 @@ pub trait PageModel {
     }
     fn on_info_clicked(&self) {}
 
+    // Share button
+
+    fn has_share_button(&self) -> bool {
+        false
+    }
+    fn on_share_clicked(&self) {}
+
     // Subtitle click
 
     fn has_subtitle_link(&self) -> bool {

--- a/src/app/components/widgets/playlist/song_actions.rs
+++ b/src/app/components/widgets/playlist/song_actions.rs
@@ -1,4 +1,3 @@
-use gdk::prelude::*;
 use gio::SimpleAction;
 
 use crate::app::models::SongDescription;
@@ -37,10 +36,7 @@ impl SongDescription {
         let copy_link = SimpleAction::new(name.unwrap_or("copy_link"), None);
         copy_link.connect_activate(move |_, _| {
             let link = format!("https://open.spotify.com/track/{track_id}");
-            let clipboard = gdk::Display::default().unwrap().clipboard();
-            clipboard
-                .set_content(Some(&gdk::ContentProvider::for_value(&link.to_value())))
-                .expect("Failed to set clipboard content");
+            crate::app::components::copy_link_to_clipboard(&link);
         });
         copy_link
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -117,6 +117,7 @@ impl App {
                 worker.clone(),
             ),
             App::make_search_button(builder, dispatcher.box_clone()),
+            App::make_clipboard_import(builder, Rc::clone(model), dispatcher.box_clone()),
             App::make_user_menu(builder, Rc::clone(model), dispatcher),
             App::make_notification(builder),
         ];
@@ -259,6 +260,15 @@ impl App {
     fn make_notification(builder: &gtk::Builder) -> Box<Notification> {
         let toast_overlay: libadwaita::ToastOverlay = builder.object("main").unwrap();
         Box::new(Notification::new(toast_overlay))
+    }
+
+    fn make_clipboard_import(
+        builder: &gtk::Builder,
+        app_model: Rc<AppModel>,
+        dispatcher: Box<dyn ActionDispatcher>,
+    ) -> Box<ClipboardImport> {
+        let window: libadwaita::ApplicationWindow = builder.object("window").unwrap();
+        Box::new(ClipboardImport::new(window, dispatcher, app_model))
     }
 
     // Main handler called in a loop

--- a/src/app/state/app_state.rs
+++ b/src/app/state/app_state.rs
@@ -7,7 +7,7 @@ use crate::app::state::{
     playback_state::{PlaybackAction, PlaybackEvent, PlaybackState},
     selection_state::{SelectionAction, SelectionContext, SelectionEvent, SelectionState},
     settings_state::{SettingsAction, SettingsEvent, SettingsState},
-    ScreenName, UpdatableState,
+    ScreenName, SpotifyLink, UpdatableState,
 };
 
 // It's a big one...
@@ -42,28 +42,19 @@ pub enum AppAction {
 
 // Not actual actions, just neat wrappers
 impl AppAction {
-    // An action to open a Spotify URI
+    // An action to open a Spotify URI or an open.spotify.com URL.
+    // Track links are not resolvable synchronously (they need an API lookup to
+    // find the containing album), so they are handled separately by the caller.
     #[allow(non_snake_case)]
     pub fn OpenURI(uri: String) -> Option<Self> {
         debug!("parsing {}", &uri);
-        let mut parts = uri.split(':');
-        if parts.next()? != "spotify" {
-            return None;
-        }
-
-        // Might start with /// because of https://gitlab.gnome.org/GNOME/glib/-/issues/1886/
-        let action = parts
-            .next()?
-            .strip_prefix("///")
-            .filter(|p| !p.is_empty())?;
-        let data = parts.next()?;
-
-        match action {
-            "album" => Some(Self::ViewAlbum(data.to_string())),
-            "artist" => Some(Self::ViewArtist(data.to_string())),
-            "playlist" => Some(Self::ViewPlaylist(data.to_string())),
-            "user" => Some(Self::ViewUser(data.to_string())),
-            _ => None,
+        match SpotifyLink::parse(&uri)? {
+            SpotifyLink::Album(id) => Some(Self::ViewAlbum(id)),
+            SpotifyLink::Artist(id) => Some(Self::ViewArtist(id)),
+            SpotifyLink::Playlist(id) => Some(Self::ViewPlaylist(id)),
+            SpotifyLink::User(id) => Some(Self::ViewUser(id)),
+            // Tracks require an async album lookup; not handled here.
+            SpotifyLink::Track(_) => None,
         }
     }
 

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -7,6 +7,7 @@ mod playback_state;
 mod screen_states;
 mod selection_state;
 mod settings_state;
+mod spotify_link;
 
 pub use app_model::AppModel;
 pub use app_state::*;
@@ -16,6 +17,7 @@ pub use playback_state::*;
 pub use screen_states::*;
 pub use selection_state::*;
 pub use settings_state::*;
+pub use spotify_link::SpotifyLink;
 
 pub trait UpdatableState {
     type Action: Clone;

--- a/src/app/state/spotify_link.rs
+++ b/src/app/state/spotify_link.rs
@@ -1,0 +1,213 @@
+//! Parsing of Spotify links into a small, typed representation.
+//!
+//! Riff needs to understand two flavours of Spotify link:
+//!  - `spotify:` URIs, e.g. `spotify:album:6akEvsycLGftJxYudPjmqK`, used for
+//!    deep links / the desktop file's `HANDLES_OPEN`.
+//!  - `https://open.spotify.com/...` URLs, which is what people copy out of the
+//!    Spotify apps and web player (and what Riff itself copies via "Copy link").
+//!
+//! Real-world web URLs often carry a locale prefix (`/intl-de/track/...`) and a
+//! tracking query (`?si=...`); both are normalised away here.
+
+/// A resolved reference to something on Spotify that Riff knows how to open.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SpotifyLink {
+    Album(String),
+    Artist(String),
+    Playlist(String),
+    User(String),
+    Track(String),
+}
+
+impl SpotifyLink {
+    /// Parse a `spotify:` URI or an `open.spotify.com` URL into a [`SpotifyLink`].
+    ///
+    /// Returns `None` if the input is not a Spotify link or references a type
+    /// Riff does not know how to open.
+    pub fn parse(input: &str) -> Option<Self> {
+        let input = input.trim();
+        if input.is_empty() {
+            return None;
+        }
+
+        if let Some(rest) = input.strip_prefix("spotify:") {
+            Self::parse_uri(rest)
+        } else {
+            Self::parse_url(input)
+        }
+    }
+
+    /// Parse the part of a `spotify:` URI following the `spotify:` scheme, e.g.
+    /// `album:6akEvsycLGftJxYudPjmqK`.
+    fn parse_uri(rest: &str) -> Option<Self> {
+        // glib may hand us URIs with a leading `///` because of
+        // https://gitlab.gnome.org/GNOME/glib/-/issues/1886/
+        let rest = rest.trim_start_matches('/');
+        let mut parts = rest.split(':');
+        let kind = parts.next()?;
+        let id = parts.next()?;
+        Self::from_kind_and_id(kind, id)
+    }
+
+    /// Parse an `https://open.spotify.com/...` URL.
+    fn parse_url(input: &str) -> Option<Self> {
+        // Strip the scheme; accept both http and https.
+        let rest = input
+            .strip_prefix("https://")
+            .or_else(|| input.strip_prefix("http://"))?;
+
+        // Only `open.spotify.com` links are supported.
+        let rest = rest.strip_prefix("open.spotify.com/")?;
+
+        // Drop any query string or fragment (e.g. `?si=...`).
+        let path = rest
+            .split(['?', '#'])
+            .next()
+            .unwrap_or(rest)
+            .trim_matches('/');
+
+        let mut segments = path.split('/').filter(|s| !s.is_empty());
+        let mut kind = segments.next()?;
+
+        // Skip a locale prefix such as `intl-de`.
+        if kind.starts_with("intl-") {
+            kind = segments.next()?;
+        }
+
+        let id = segments.next()?;
+        Self::from_kind_and_id(kind, id)
+    }
+
+    fn from_kind_and_id(kind: &str, id: &str) -> Option<Self> {
+        if id.is_empty() {
+            return None;
+        }
+        let id = id.to_string();
+        match kind {
+            "album" => Some(Self::Album(id)),
+            "artist" => Some(Self::Artist(id)),
+            "playlist" => Some(Self::Playlist(id)),
+            "user" => Some(Self::User(id)),
+            "track" => Some(Self::Track(id)),
+            _ => None,
+        }
+    }
+
+    /// A short, human-readable label for the kind of link, used in the
+    /// "open this link?" prompt.
+    pub fn kind_label(&self) -> &'static str {
+        match self {
+            Self::Album(_) => "album",
+            Self::Artist(_) => "artist",
+            Self::Playlist(_) => "playlist",
+            Self::User(_) => "profile",
+            Self::Track(_) => "song",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_uri_album() {
+        assert_eq!(
+            SpotifyLink::parse("spotify:album:6akEvsycLGftJxYudPjmqK"),
+            Some(SpotifyLink::Album("6akEvsycLGftJxYudPjmqK".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_uri_all_types() {
+        assert_eq!(
+            SpotifyLink::parse("spotify:artist:abc"),
+            Some(SpotifyLink::Artist("abc".to_string()))
+        );
+        assert_eq!(
+            SpotifyLink::parse("spotify:playlist:abc"),
+            Some(SpotifyLink::Playlist("abc".to_string()))
+        );
+        assert_eq!(
+            SpotifyLink::parse("spotify:user:abc"),
+            Some(SpotifyLink::User("abc".to_string()))
+        );
+        assert_eq!(
+            SpotifyLink::parse("spotify:track:abc"),
+            Some(SpotifyLink::Track("abc".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_uri_with_glib_slashes() {
+        // glib sometimes prepends `///` to the first URI component.
+        assert_eq!(
+            SpotifyLink::parse("spotify:///playlist:xyz"),
+            Some(SpotifyLink::Playlist("xyz".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_url_track() {
+        assert_eq!(
+            SpotifyLink::parse("https://open.spotify.com/track/6rqhFgbbKwnb9MLmUQDhG6"),
+            Some(SpotifyLink::Track("6rqhFgbbKwnb9MLmUQDhG6".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_url_with_query() {
+        assert_eq!(
+            SpotifyLink::parse(
+                "https://open.spotify.com/album/6akEvsycLGftJxYudPjmqK?si=abcdef123456"
+            ),
+            Some(SpotifyLink::Album("6akEvsycLGftJxYudPjmqK".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_url_with_locale_prefix() {
+        assert_eq!(
+            SpotifyLink::parse("https://open.spotify.com/intl-de/track/abc?si=xyz"),
+            Some(SpotifyLink::Track("abc".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_url_http_scheme() {
+        assert_eq!(
+            SpotifyLink::parse("http://open.spotify.com/artist/abc"),
+            Some(SpotifyLink::Artist("abc".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_url_trailing_slash() {
+        assert_eq!(
+            SpotifyLink::parse("https://open.spotify.com/playlist/abc/"),
+            Some(SpotifyLink::Playlist("abc".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_with_surrounding_whitespace() {
+        assert_eq!(
+            SpotifyLink::parse("  spotify:album:abc\n"),
+            Some(SpotifyLink::Album("abc".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_reject_non_spotify() {
+        assert_eq!(SpotifyLink::parse(""), None);
+        assert_eq!(SpotifyLink::parse("hello world"), None);
+        assert_eq!(SpotifyLink::parse("https://example.com/track/abc"), None);
+        assert_eq!(
+            SpotifyLink::parse("https://open.spotify.com/unknown/abc"),
+            None
+        );
+        assert_eq!(SpotifyLink::parse("spotify:album:"), None);
+        assert_eq!(SpotifyLink::parse("spotify:album"), None);
+        assert_eq!(SpotifyLink::parse("https://open.spotify.com/track"), None);
+    }
+}


### PR DESCRIPTION
Detects Spotify links from the clipboard and allows importing them into the app. Supports links for albums, artists, playlists, users, and the currently playing track.
  
Changes:
- Added clipboard monitoring and link parsing (spotify_link.rs)
- New clipboard_import shell component for handling detected links
- Added share/copy-link buttons to detail pages (album, artist, playlist, user, now playing)
- Added a ClipboardLink component for exposing copy-link actions on song rows
- Extended the API client with lookup methods for resolving Spotify URIs/URLs

Resolves https://github.com/Diegovsky/riff/issues/7

<img width="1709" height="1023" alt="image" src="https://github.com/user-attachments/assets/57b2f04f-8cd8-4d5f-ad6a-dd1150da9fe8" />
