### PR TITLE
Skip Explicit Tracks Option

### DIFF
--- a/data/dev.diegovsky.Riff.gschema.xml
+++ b/data/dev.diegovsky.Riff.gschema.xml
@@ -75,6 +75,10 @@
       <default>true</default>
       <summary>A flag to enable gap-less playback</summary>
     </key>
+    <key name="skip-explicit" type="b">
+      <default>false</default>
+      <summary>Skip tracks marked as explicit</summary>
+    </key>
     <key name='alsa-device' type='s'>
       <default>'default'</default>
       <summary>Alsa device (if audio backend is 'alsa')</summary>

--- a/src/api/api_models.rs
+++ b/src/api/api_models.rs
@@ -289,6 +289,13 @@ pub struct User {
     pub display_name: String,
     pub product: Option<String>,
     pub images: Option<Vec<Image>>,
+    pub explicit_content: Option<ExplicitContentSettings>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct ExplicitContentSettings {
+    pub filter_enabled: bool,
+    pub filter_locked: bool,
 }
 
 impl WithImages for User {
@@ -382,6 +389,8 @@ pub struct AlbumTrackItem {
     pub name: String,
     pub duration_ms: i64,
     pub artists: Vec<Artist>,
+    #[serde(default)]
+    pub explicit: bool,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -524,6 +533,7 @@ where
                     name,
                     duration_ms,
                     track_number,
+                    explicit,
                 } = track;
                 let artists = artists
                     .into_iter()
@@ -555,6 +565,7 @@ where
                     album: album_ref,
                     duration_ms: duration_ms as u32,
                     art,
+                    explicit,
                 })
             })
             .collect();

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -17,14 +17,20 @@ pub async fn clear_user_cache() -> Option<()> {
         .ok()
 }
 
-/// Check whether the given access token belongs to a Spotify Premium account.
-/// This uses the standard API client infrastructure but authenticates with an
-/// explicit token (for use during login before credentials are persisted).
+/// Result of checking the user's profile at login time.
+pub struct UserProfileCheck {
+    pub is_premium: bool,
+    pub explicit_filter_enabled: bool,
+    pub explicit_filter_locked: bool,
+}
+
+/// Check the user's profile via GET /v1/me.
+/// Returns premium status and whether the account has the explicit content
+/// filter enabled/locked.
 ///
-/// Returns Ok(true) for premium, Ok(false) for confirmed non-premium, or an
-/// Err if the API call itself failed (network, auth, rate-limit, etc.).
-pub async fn check_premium(token: &str) -> Result<bool, SpotifyApiError> {
-    debug!("Checking premium status via GET /v1/me");
+/// Returns Ok with the profile info, or Err if the API call itself failed.
+pub async fn check_user_profile(token: &str) -> Result<UserProfileCheck, SpotifyApiError> {
+    debug!("Checking user profile via GET /v1/me");
     let client = SpotifyClient::new(TokenStore::new());
     let response = match client.get_me().send_with_token(token).await {
         Ok(r) => r,
@@ -41,10 +47,14 @@ pub async fn check_premium(token: &str) -> Result<bool, SpotifyApiError> {
         }
     };
     debug!(
-        "GET /v1/me succeeded: id={}, display_name={}, product={:?}",
-        user.id, user.display_name, user.product
+        "GET /v1/me succeeded: id={}, display_name={}, product={:?}, explicit_filter={:?}",
+        user.id,
+        user.display_name,
+        user.product,
+        user.explicit_content.as_ref().map(|e| e.filter_enabled)
     );
-    Ok(match user.product.as_deref() {
+
+    let is_premium = match user.product.as_deref() {
         Some("premium") => true,
         // The product field may be absent if the Spotify app is in Development
         // Mode (removed in the Feb 2026 API changes). Treat absent as premium
@@ -55,5 +65,16 @@ pub async fn check_premium(token: &str) -> Result<bool, SpotifyApiError> {
             error!("Account product type is {:?}, not premium", other);
             false
         }
+    };
+
+    let (explicit_filter_enabled, explicit_filter_locked) = match &user.explicit_content {
+        Some(ec) => (ec.filter_enabled, ec.filter_locked),
+        None => (false, false),
+    };
+
+    Ok(UserProfileCheck {
+        is_premium,
+        explicit_filter_enabled,
+        explicit_filter_locked,
     })
 }

--- a/src/app/components/pages/settings/settings.blp
+++ b/src/app/components/pages/settings/settings.blp
@@ -39,6 +39,16 @@ template $SettingsWindow : Adw.PreferencesDialog {
           ]
         };
       }
+
+      Adw.SwitchRow skip_explicit_switch {
+        /* Translators: Title for the skip explicit tracks toggle in preferences */
+
+        title: _("Skip Explicit Tracks");
+
+        /* Translators: Description for the skip explicit tracks toggle */
+
+        subtitle: _("Automatically skip tracks marked as explicit");
+      }
     }
 
     Adw.PreferencesGroup {

--- a/src/app/components/pages/settings/settings.rs
+++ b/src/app/components/pages/settings/settings.rs
@@ -3,6 +3,8 @@ use crate::app::AppEvent;
 use crate::feature_flags::{self, FeatureFlag};
 use crate::settings::RiffSettings;
 
+use std::rc::Rc;
+
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::CompositeTemplate;
@@ -46,6 +48,9 @@ mod imp {
 
         #[template_child]
         pub close_behavior: TemplateChild<libadwaita::ComboRow>,
+
+        #[template_child]
+        pub skip_explicit_switch: TemplateChild<libadwaita::SwitchRow>,
 
         #[template_child]
         pub volume_curve: TemplateChild<libadwaita::ComboRow>,
@@ -508,6 +513,16 @@ impl SettingsDialog {
                 })
             })
             .build();
+
+        // Skip explicit tracks (local preference). When the account locks the
+        // filter, `show_self` overrides this switch to on and disables it.
+        let skip_explicit_switch = widget
+            .skip_explicit_switch
+            .downcast_ref::<libadwaita::SwitchRow>()
+            .expect("skip_explicit_switch must be a SwitchRow");
+        settings
+            .bind("skip-explicit", skip_explicit_switch, "active")
+            .build();
     }
 
     fn bind_feature_flags(&self) {
@@ -570,34 +585,58 @@ impl SettingsDialog {
         self.imp().pan.lock();
         self.imp().pitch.lock();
     }
+
+    /// Apply the Spotify account's explicit content filter lock to the toggle.
+    ///
+    /// When the account has the filter locked (e.g. a family plan parental
+    /// control), the switch is forced on, made insensitive so it cannot be
+    /// changed, and given a tooltip explaining why. Otherwise the switch is
+    /// interactive and reflects the local preference.
+    fn set_explicit_filter_locked(&self, locked: bool) {
+        let switch = &self.imp().skip_explicit_switch;
+        if locked {
+            switch.set_active(true);
+            switch.set_sensitive(false);
+            switch.set_tooltip_text(Some(&gettextrs::gettext(
+                "Locked by a Family plan parental control and cannot be changed here.",
+            )));
+        } else {
+            switch.set_sensitive(true);
+            switch.set_tooltip_text(None);
+        }
+    }
 }
 
 pub struct Settings {
     parent: gtk::Window,
     settings_dialog: SettingsDialog,
+    model: Rc<SettingsModel>,
 }
 
 impl Settings {
     pub fn new(parent: gtk::Window, model: SettingsModel) -> Self {
         let settings_dialog = SettingsDialog::new();
+        let model = Rc::new(model);
 
+        let close_model = model.clone();
         settings_dialog.connect_close(move || {
             let new_settings = RiffSettings::new_from_gsettings().unwrap_or_default();
             // Only stop the player for changes that require a full reload.
             // Equalizer changes are applied live and must not interrupt playback.
-            if model
+            if close_model
                 .settings()
                 .player_settings
                 .requires_reload(&new_settings.player_settings)
             {
-                model.stop_player();
+                close_model.stop_player();
             }
-            model.set_settings();
+            close_model.set_settings();
         });
 
         Self {
             parent,
             settings_dialog,
+            model,
         }
     }
 
@@ -608,6 +647,10 @@ impl Settings {
     pub fn show_self(&self) {
         // Locks are UI-only and must not be stateful between openings.
         self.settings_dialog.reset_locks();
+        // Reflect the account's explicit content filter lock each time the
+        // dialog opens, since it becomes known only after login.
+        self.settings_dialog
+            .set_explicit_filter_locked(self.model.explicit_filter_locked());
         self.dialog().present(Some(&self.parent));
     }
 }

--- a/src/app/components/pages/settings/settings_model.rs
+++ b/src/app/components/pages/settings/settings_model.rs
@@ -29,4 +29,11 @@ impl SettingsModel {
         let state = self.app_model.get_state();
         state.settings.settings.clone()
     }
+
+    /// Whether the logged-in Spotify account has locked its explicit content
+    /// filter (e.g. via a family plan parental control). When locked, the user
+    /// cannot disable explicit-track skipping in Riff.
+    pub fn explicit_filter_locked(&self) -> bool {
+        self.app_model.get_state().playback.explicit_filter_locked()
+    }
 }

--- a/src/app/components/player_notifier.rs
+++ b/src/app/components/player_notifier.rs
@@ -8,7 +8,8 @@ use librespot::core::SpotifyUri;
 
 use crate::app::components::EventListener;
 use crate::app::state::{
-    Device, LoginAction, LoginEvent, LoginStartedEvent, PlaybackEvent, SettingsEvent,
+    Device, LoginAction, LoginEvent, LoginStartedEvent, PlaybackAction, PlaybackEvent,
+    SettingsEvent,
 };
 use crate::app::{ActionDispatcher, AppAction, AppEvent, AppModel, SongsSource};
 use crate::connect::ConnectCommand;
@@ -54,6 +55,7 @@ impl PlayerNotifier {
         connect_command_sender: UnboundedSender<ConnectCommand>,
     ) -> Self {
         let dsp_settings = Self::watch_dsp_settings(command_sender.clone());
+        Self::watch_skip_explicit_setting(&dsp_settings, dispatcher.as_ref());
         Self {
             app_model,
             dispatcher,
@@ -61,6 +63,17 @@ impl PlayerNotifier {
             connect_command_sender,
             _dsp_settings: dsp_settings,
         }
+    }
+
+    /// Watch the skip-explicit GSettings key (the preferences toggle) and
+    /// dispatch a PlaybackAction whenever it changes, so the playback state
+    /// stays in sync with the user's local preference.
+    fn watch_skip_explicit_setting(settings: &gio::Settings, dispatcher: &dyn ActionDispatcher) {
+        let d = dispatcher.box_clone();
+        settings.connect_changed(Some("skip-explicit"), move |settings, _| {
+            let skip = settings.boolean("skip-explicit");
+            d.dispatch(PlaybackAction::SetSkipExplicit(skip).into());
+        });
     }
 
     /// Watch the equalizer, mono-audio, pan, and pitch GSettings keys and push
@@ -216,6 +229,14 @@ impl PlayerNotifier {
             PlaybackEvent::PlaybackResumed => Some(Command::PlayerResume),
             PlaybackEvent::PlaybackStopped => Some(Command::PlayerStop),
             PlaybackEvent::VolumeSet(volume) => Some(Command::PlayerSetVolume(*volume)),
+            PlaybackEvent::SkipExplicitChanged(skip) => {
+                // Sync GSettings with the internal state so the UI toggle
+                // reflects changes forced by the account's explicit filter.
+                // GSettings deduplicates writes of the same value, so this
+                // won't cause an infinite loop with the watcher.
+                self._dsp_settings.set_boolean("skip-explicit", *skip).ok();
+                None
+            }
             PlaybackEvent::TrackChanged(id) => {
                 info!("track changed: {}", id);
                 SpotifyId::from_base62(id)

--- a/src/app/components/widgets/details_page/model.rs
+++ b/src/app/components/widgets/details_page/model.rs
@@ -385,6 +385,7 @@ mod tests {
             duration_ms: 1000,
             art: None,
             track_number: None,
+            explicit: false,
         }
     }
 

--- a/src/app/models/main.rs
+++ b/src/app/models/main.rs
@@ -222,6 +222,7 @@ pub struct SongDescription {
     pub album: AlbumRef,
     pub duration_ms: u32,
     pub art: Option<ImageSet>,
+    pub explicit: bool,
 }
 
 impl SongDescription {
@@ -371,6 +372,7 @@ mod tests {
             duration_ms: 1000,
             art: None,
             track_number: None,
+            explicit: false,
         }
     }
 

--- a/src/app/models/songs/support.rs
+++ b/src/app/models/songs/support.rs
@@ -469,6 +469,7 @@ mod tests {
             duration_ms: 1000,
             art: None,
             track_number: None,
+            explicit: false,
         }
     }
 

--- a/src/app/state/playback_state.rs
+++ b/src/app/state/playback_state.rs
@@ -19,6 +19,11 @@ pub struct PlaybackState {
     repeat: RepeatMode,
     is_playing: bool,
     is_shuffled: bool,
+    // Whether to skip explicit tracks
+    skip_explicit: bool,
+    // Whether the Spotify account has locked the explicit filter (e.g. via a
+    // family plan parental control). When locked, skipping cannot be disabled.
+    explicit_filter_locked: bool,
     // Last volume that was applied (0.0..=1.0). Initialised to a sentinel
     // outside the valid range so the first `SetVolume` always propagates.
     volume: f64,
@@ -37,6 +42,10 @@ impl PlaybackState {
 
     pub fn is_shuffled(&self) -> bool {
         self.is_shuffled
+    }
+
+    pub fn explicit_filter_locked(&self) -> bool {
+        self.explicit_filter_locked
     }
 
     pub fn repeat_mode(&self) -> RepeatMode {
@@ -200,6 +209,58 @@ impl PlaybackState {
         })
     }
 
+    /// Advance to the next non-explicit track. If skip_explicit is enabled,
+    /// keeps skipping forward until a non-explicit track is found or no more
+    /// tracks remain. Always calls self.stop() before returning None.
+    fn play_next_skipping_explicit(&mut self) -> Option<String> {
+        if !self.skip_explicit {
+            return self.play_next();
+        }
+
+        // Limit iterations to avoid infinite loops in repeat mode with all-explicit playlists
+        let max_skips = self.songs.len();
+        for _ in 0..max_skips {
+            let id = match self.play_next() {
+                Some(id) => id,
+                None => {
+                    // No more tracks available - stop playback
+                    self.stop();
+                    return None;
+                }
+            };
+            if !self.current_song_is_explicit() {
+                return Some(id);
+            }
+            debug!("Skipping explicit track '{}'", id);
+        }
+        // All remaining tracks are explicit - stop playback
+        self.stop();
+        None
+    }
+
+    /// Returns true if the current song is marked as explicit.
+    fn current_song_is_explicit(&self) -> bool {
+        self.current_song().map(|s| s.explicit).unwrap_or(false)
+    }
+
+    /// If skipping is enabled and the current track is explicit, advance to the
+    /// next non-explicit track. Used when the filter is turned on (locally or by
+    /// the account) while an explicit track is already playing. Returns the
+    /// playback events to emit, if any.
+    fn skip_current_if_explicit(&mut self) -> Vec<PlaybackEvent> {
+        if self.skip_explicit && self.current_song_is_explicit() {
+            debug!("Filter enabled while an explicit track is current; skipping");
+            if let Some(next_id) = self.play_next_skipping_explicit() {
+                vec![PlaybackEvent::TrackChanged(next_id)]
+            } else {
+                // play_next_skipping_explicit already called self.stop()
+                vec![PlaybackEvent::PlaybackStopped]
+            }
+        } else {
+            vec![]
+        }
+    }
+
     pub fn next_index(&self) -> Option<usize> {
         // When shuffled, we can only play songs that are actually loaded
         let len = if self.is_shuffled {
@@ -228,6 +289,50 @@ impl PlaybackState {
                 None
             }
         })
+    }
+
+    /// Go to the previous non-explicit track. If skip_explicit is enabled,
+    /// keeps going backwards until a non-explicit track is found or no more
+    /// tracks remain. Returns Some(id) if a track was found, None if playback
+    /// should seek to start (position > 2s) or if all previous tracks are
+    /// explicit (in which case playback is stopped).
+    fn play_prev_skipping_explicit(&mut self) -> Option<String> {
+        if !self.skip_explicit {
+            return self.play_prev();
+        }
+
+        // Delegate the "more than 2 seconds in, seek to start" check to
+        // play_prev itself on the first call. If it returns None, that means
+        // it seeked to start (or there is no previous track) rather than
+        // changing track, so leave playback untouched.
+        let first = self.play_prev()?;
+        if !self.current_song_is_explicit() {
+            return Some(first);
+        }
+        debug!("Skipping explicit track '{}' (previous)", first);
+
+        // Continue skipping backwards. Force seek position to 0 before each
+        // call so play_prev doesn't trigger the "restart current track" path.
+        let max_skips = self.songs.len();
+        for _ in 1..max_skips {
+            self.seek_position.set(0, true);
+            let id = match self.play_prev() {
+                Some(id) => id,
+                None => {
+                    // Reached the beginning with only explicit tracks behind
+                    // us - stop playback.
+                    self.stop();
+                    return None;
+                }
+            };
+            if !self.current_song_is_explicit() {
+                return Some(id);
+            }
+            debug!("Skipping explicit track '{}' (previous)", id);
+        }
+        // All previous tracks are explicit - stop playback
+        self.stop();
+        None
     }
 
     pub fn prev_index(&self) -> Option<usize> {
@@ -287,6 +392,8 @@ impl Default for PlaybackState {
             repeat: RepeatMode::None,
             is_playing: false,
             is_shuffled: false,
+            skip_explicit: false,
+            explicit_filter_locked: false,
             volume: -1.0,
         }
     }
@@ -300,6 +407,12 @@ pub enum PlaybackAction {
     Stop,
     SetRepeatMode(RepeatMode),
     SetShuffled(bool),
+    SetSkipExplicit(bool),
+    // Sync the explicit content filter lock from the Spotify account profile.
+    // A locked filter (e.g. a family plan parental control) forces skipping on
+    // and prevents the user from disabling it. An unlocked account setting does
+    // not change the local preference, which defaults to off.
+    SetExplicitFilterLocked(bool),
     ToggleRepeat,
     ToggleShuffle,
     Seek(u32),
@@ -347,6 +460,10 @@ pub enum PlaybackEvent {
     PlaybackStopped,
     SwitchedDevice(Device),
     AvailableDevicesChanged,
+    /// Emitted when the skip_explicit preference changes (either locally or
+    /// forced by the account's explicit content filter). Used to sync GSettings
+    /// with the internal state.
+    SkipExplicitChanged(bool),
 }
 
 impl From<PlaybackEvent> for AppEvent {
@@ -403,12 +520,37 @@ impl UpdatableState for PlaybackState {
                 self.set_shuffled(shuffled);
                 vec![PlaybackEvent::ShuffleChanged(shuffled)]
             }
+            PlaybackAction::SetSkipExplicit(skip) => {
+                let changed = self.skip_explicit != skip;
+                self.skip_explicit = skip;
+                let mut events = Vec::new();
+                if changed {
+                    events.push(PlaybackEvent::SkipExplicitChanged(skip));
+                }
+                // If enabling while an explicit track is playing, skip it now.
+                events.extend(self.skip_current_if_explicit());
+                events
+            }
+            PlaybackAction::SetExplicitFilterLocked(locked) => {
+                self.explicit_filter_locked = locked;
+                let mut events = Vec::new();
+                // A locked account filter forces skipping on. An unlocked
+                // account leaves the local preference untouched (default off).
+                if locked && !self.skip_explicit {
+                    self.skip_explicit = true;
+                    events.push(PlaybackEvent::SkipExplicitChanged(true));
+                }
+                // If the filter just turned on while an explicit track is
+                // playing, skip it now.
+                events.extend(self.skip_current_if_explicit());
+                events
+            }
             PlaybackAction::ToggleShuffle => {
                 self.set_shuffled(!self.is_shuffled);
                 vec![PlaybackEvent::ShuffleChanged(self.is_shuffled)]
             }
             PlaybackAction::Next => {
-                if let Some(id) = self.play_next() {
+                if let Some(id) = self.play_next_skipping_explicit() {
                     vec![PlaybackEvent::TrackChanged(id)]
                 } else {
                     self.stop();
@@ -420,15 +562,34 @@ impl UpdatableState for PlaybackState {
                 vec![PlaybackEvent::PlaybackStopped]
             }
             PlaybackAction::Previous => {
-                if let Some(id) = self.play_prev() {
+                if let Some(id) = self.play_prev_skipping_explicit() {
                     vec![PlaybackEvent::TrackChanged(id)]
-                } else {
+                } else if self.list_position.is_some() {
+                    // A track is still loaded, so play_prev seeked to its start
+                    // rather than stopping. (list_position stays Some when
+                    // paused, so we can't rely on is_playing here.)
                     vec![PlaybackEvent::TrackSeeked(0)]
+                } else {
+                    // All previous tracks were explicit and playback was
+                    // stopped (stop() clears list_position).
+                    vec![PlaybackEvent::PlaybackStopped]
                 }
             }
             PlaybackAction::Load(id) => {
                 if self.play(&id) {
-                    vec![PlaybackEvent::TrackChanged(id)]
+                    // If skip_explicit is enabled and the loaded track is explicit,
+                    // skip forward to the next non-explicit track instead.
+                    if self.skip_explicit && self.current_song_is_explicit() {
+                        debug!("Requested explicit track '{}', skipping", id);
+                        if let Some(next_id) = self.play_next_skipping_explicit() {
+                            vec![PlaybackEvent::TrackChanged(next_id)]
+                        } else {
+                            // play_next_skipping_explicit already called self.stop()
+                            vec![PlaybackEvent::PlaybackStopped]
+                        }
+                    } else {
+                        vec![PlaybackEvent::TrackChanged(id)]
+                    }
                 } else {
                     vec![]
                 }
@@ -569,6 +730,7 @@ mod tests {
             duration_ms: 1000,
             art: None,
             track_number: None,
+            explicit: false,
         }
     }
 
@@ -956,5 +1118,263 @@ mod tests {
             !failed,
             "Playback stopped because shuffle picked an unloaded song index"
         );
+    }
+
+    fn explicit_song(id: &str) -> SongDescription {
+        SongDescription {
+            id: id.to_string(),
+            uri: "".to_string(),
+            title: "Explicit Title".to_string(),
+            artists: vec![],
+            album: AlbumRef {
+                id: "".to_string(),
+                name: "".to_string(),
+            },
+            duration_ms: 1000,
+            art: None,
+            track_number: None,
+            explicit: true,
+        }
+    }
+
+    #[test]
+    fn test_skip_explicit_next() {
+        let mut state = PlaybackState::default();
+        state.update_with(Cow::Owned(PlaybackAction::SetSkipExplicit(true)));
+        state.queue(vec![
+            song("1"),
+            explicit_song("2"),
+            explicit_song("3"),
+            song("4"),
+        ]);
+
+        state.play("1");
+        assert!(state.is_playing());
+        assert_eq!(state.current_song_id(), Some("1".to_string()));
+
+        // Next should skip the two explicit tracks and land on "4"
+        let events = state.update_with(Cow::Owned(PlaybackAction::Next));
+        assert!(state.is_playing());
+        assert_eq!(state.current_song_id(), Some("4".to_string()));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::TrackChanged(id) if id == "4")));
+    }
+
+    #[test]
+    fn test_skip_explicit_load() {
+        let mut state = PlaybackState::default();
+        state.update_with(Cow::Owned(PlaybackAction::SetSkipExplicit(true)));
+        state.queue(vec![song("1"), explicit_song("2"), song("3")]);
+
+        // Trying to load an explicit track should skip forward to "3"
+        let events = state.update_with(Cow::Owned(PlaybackAction::Load("2".to_string())));
+        assert!(state.is_playing());
+        assert_eq!(state.current_song_id(), Some("3".to_string()));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::TrackChanged(id) if id == "3")));
+    }
+
+    #[test]
+    fn test_skip_explicit_all_explicit_stops_playback() {
+        let mut state = PlaybackState::default();
+        state.update_with(Cow::Owned(PlaybackAction::SetSkipExplicit(true)));
+        state.queue(vec![song("1"), explicit_song("2"), explicit_song("3")]);
+
+        state.play("1");
+        assert!(state.is_playing());
+
+        // Next should try to advance but all remaining are explicit - stop
+        let events = state.update_with(Cow::Owned(PlaybackAction::Next));
+        assert!(!state.is_playing());
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::PlaybackStopped)));
+    }
+
+    #[test]
+    fn test_skip_explicit_disabled_plays_explicit() {
+        let mut state = PlaybackState::default();
+        // skip_explicit is false by default
+        state.queue(vec![song("1"), explicit_song("2"), song("3")]);
+
+        state.play("1");
+        let events = state.update_with(Cow::Owned(PlaybackAction::Next));
+        assert!(state.is_playing());
+        // Should play the explicit track normally
+        assert_eq!(state.current_song_id(), Some("2".to_string()));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::TrackChanged(id) if id == "2")));
+    }
+
+    #[test]
+    fn test_skip_explicit_previous() {
+        let mut state = PlaybackState::default();
+        state.update_with(Cow::Owned(PlaybackAction::SetSkipExplicit(true)));
+        state.queue(vec![
+            song("1"),
+            explicit_song("2"),
+            explicit_song("3"),
+            song("4"),
+        ]);
+
+        state.play("4");
+        assert!(state.is_playing());
+        assert_eq!(state.current_song_id(), Some("4".to_string()));
+
+        // Previous should skip the two explicit tracks and land on "1"
+        let events = state.update_with(Cow::Owned(PlaybackAction::Previous));
+        assert!(state.is_playing());
+        assert_eq!(state.current_song_id(), Some("1".to_string()));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::TrackChanged(id) if id == "1")));
+    }
+
+    #[test]
+    fn test_account_explicit_filter_locked_forces_skip() {
+        let mut state = PlaybackState::default();
+        // Account has the filter locked (e.g. family plan control)
+        state.update_with(Cow::Owned(PlaybackAction::SetExplicitFilterLocked(true)));
+        assert!(state.skip_explicit);
+        assert!(state.explicit_filter_locked());
+
+        state.queue(vec![song("1"), explicit_song("2"), song("3")]);
+        state.play("1");
+        let events = state.update_with(Cow::Owned(PlaybackAction::Next));
+        assert_eq!(state.current_song_id(), Some("3".to_string()));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::TrackChanged(id) if id == "3")));
+    }
+
+    #[test]
+    fn test_account_explicit_filter_unlocked_defaults_off() {
+        let mut state = PlaybackState::default();
+        // An unlocked account must not auto-enable skipping: default is off.
+        state.update_with(Cow::Owned(PlaybackAction::SetExplicitFilterLocked(false)));
+        assert!(!state.skip_explicit);
+        assert!(!state.explicit_filter_locked());
+    }
+
+    #[test]
+    fn test_account_explicit_filter_unlocked_preserves_local_pref() {
+        let mut state = PlaybackState::default();
+        // User locally enabled skipping
+        state.update_with(Cow::Owned(PlaybackAction::SetSkipExplicit(true)));
+        assert!(state.skip_explicit);
+
+        // An unlocked account should not disable the user's local preference.
+        state.update_with(Cow::Owned(PlaybackAction::SetExplicitFilterLocked(false)));
+        assert!(state.skip_explicit);
+        assert!(!state.explicit_filter_locked());
+    }
+
+    #[test]
+    fn test_enable_filter_skips_current_explicit_track() {
+        let mut state = PlaybackState::default();
+        state.queue(vec![song("1"), explicit_song("2"), song("3")]);
+        state.play("2");
+        assert_eq!(state.current_song_id(), Some("2".to_string()));
+        assert!(state.is_playing());
+
+        // Enabling the filter while an explicit track is playing skips it now.
+        let events = state.update_with(Cow::Owned(PlaybackAction::SetSkipExplicit(true)));
+        assert_eq!(state.current_song_id(), Some("3".to_string()));
+        assert!(state.is_playing());
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::TrackChanged(id) if id == "3")));
+    }
+
+    #[test]
+    fn test_lock_filter_skips_current_explicit_track() {
+        let mut state = PlaybackState::default();
+        state.queue(vec![song("1"), explicit_song("2"), song("3")]);
+        state.play("2");
+        assert_eq!(state.current_song_id(), Some("2".to_string()));
+
+        // Account lock arriving mid-playback skips the current explicit track.
+        let events = state.update_with(Cow::Owned(PlaybackAction::SetExplicitFilterLocked(true)));
+        assert_eq!(state.current_song_id(), Some("3".to_string()));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::TrackChanged(id) if id == "3")));
+    }
+
+    #[test]
+    fn test_enable_filter_leaves_non_explicit_current_track() {
+        let mut state = PlaybackState::default();
+        state.queue(vec![song("1"), explicit_song("2")]);
+        state.play("1");
+
+        // Current track is not explicit: enabling the filter does not skip.
+        let events = state.update_with(Cow::Owned(PlaybackAction::SetSkipExplicit(true)));
+        assert_eq!(state.current_song_id(), Some("1".to_string()));
+        // Only the state-change notification is emitted, no track change.
+        assert!(events
+            .iter()
+            .all(|e| matches!(e, PlaybackEvent::SkipExplicitChanged(true))));
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn test_enable_filter_all_explicit_stops_playback() {
+        let mut state = PlaybackState::default();
+        state.queue(vec![explicit_song("1"), explicit_song("2")]);
+        state.play("1");
+        assert!(state.is_playing());
+
+        // Enabling the filter with only explicit tracks left stops playback.
+        let events = state.update_with(Cow::Owned(PlaybackAction::SetSkipExplicit(true)));
+        assert!(!state.is_playing());
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::PlaybackStopped)));
+    }
+
+    #[test]
+    fn test_previous_while_paused_seeks_to_start() {
+        let mut state = PlaybackState::default();
+        state.queue(vec![song("1"), song("2")]);
+        state.play("2");
+        // Simulate being more than 2s into the track so Previous seeks to start.
+        state.seek_position.set(5000, true);
+        // Pause: is_playing becomes false, but list_position stays Some.
+        state.toggle_play();
+        assert!(!state.is_playing());
+
+        // Previous should seek to start, NOT stop playback.
+        let events = state.update_with(Cow::Owned(PlaybackAction::Previous));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::TrackSeeked(0))));
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::PlaybackStopped)));
+        assert_eq!(state.current_song_id(), Some("2".to_string()));
+    }
+
+    #[test]
+    fn test_skip_explicit_previous_all_explicit_stops_playback() {
+        let mut state = PlaybackState::default();
+        state.update_with(Cow::Owned(PlaybackAction::SetSkipExplicit(true)));
+        state.queue(vec![explicit_song("1"), explicit_song("2"), song("3")]);
+
+        state.play("3");
+        assert!(state.is_playing());
+
+        // Previous should try to go back but all previous tracks are explicit,
+        // so playback stops and PlaybackStopped is emitted (not TrackSeeked).
+        let events = state.update_with(Cow::Owned(PlaybackAction::Previous));
+        assert!(!state.is_playing());
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::PlaybackStopped)));
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::TrackSeeked(_))));
     }
 }

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -17,7 +17,10 @@ pub enum Command {
     CompleteLogin,
     RefreshToken,
     Logout,
-    PlayerLoad { track: SpotifyUri, resume: bool },
+    PlayerLoad {
+        track: SpotifyUri,
+        resume: bool,
+    },
     PlayerResume,
     PlayerPause,
     PlayerStop,
@@ -25,10 +28,27 @@ pub enum Command {
     PlayerSetVolume(f64),
     PlayerPreload(SpotifyUri),
     ReloadSettings,
-    SetEqualizer { bands: [f64; 10] },
-    SetMono { enabled: bool },
-    SetPan { pan: f64 },
-    SetPitch { cents: f64 },
+    SetEqualizer {
+        bands: [f64; 10],
+    },
+    SetMono {
+        enabled: bool,
+    },
+    SetPan {
+        pan: f64,
+    },
+    SetPitch {
+        cents: f64,
+    },
+    // Re-query the account's explicit content filter (e.g. after a track was
+    // rejected with ExplicitContentFiltered) and sync Riff's filter state.
+    RecheckExplicitFilter,
+    // Carries the result of an asynchronous explicit-filter re-check back into
+    // the command loop so the player can update its cached state.
+    ExplicitFilterRechecked {
+        filter_enabled: bool,
+        filter_locked: bool,
+    },
 }
 
 #[derive(Clone)]
@@ -55,6 +75,14 @@ impl AppPlayerDelegate {
 
     fn refresh_successful(&self) {
         self.send(LoginAction::TokenRefreshed.into())
+    }
+
+    fn set_explicit_filter_locked(&self, locked: bool) {
+        self.send(PlaybackAction::SetExplicitFilterLocked(locked).into())
+    }
+
+    fn set_skip_explicit(&self, skip: bool) {
+        self.send(PlaybackAction::SetSkipExplicit(skip).into())
     }
 
     fn report_error(&self, error: SpotifyError) {

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -89,6 +89,10 @@ pub struct SpotifyPlayerSettings {
     pub repeat: RepeatMode,
     pub volume: f64,
 
+    // Local user preference: skip tracks marked as explicit. Applied via the
+    // playback state, not librespot, so it never requires a player reload.
+    pub skip_explicit: bool,
+
     // Volume curve
     pub volume_curve: VolumeCurveType,
 
@@ -125,6 +129,8 @@ impl Default for SpotifyPlayerSettings {
             volume: 0.7,
             repeat: RepeatMode::None,
             shuffle: false,
+
+            skip_explicit: false,
 
             bitrate: Bitrate::Bitrate160,
             gapless: true,
@@ -223,6 +229,12 @@ pub struct SpotifyPlayer {
     auth_challenge: Option<AuthcodeChallenge>,
     command_sender: UnboundedSender<Command>,
 
+    // Cached "explicit filter locked" state for the account, so we avoid
+    // re-querying the profile once we know the filter is locked for the
+    // session (a locked filter cannot be unlocked without changing account
+    // settings, and forces skipping so explicit tracks are never attempted).
+    explicit_filter_locked: bool,
+
     // Receives feedback from commands or various events in the player
     delegate: AppPlayerDelegate,
 }
@@ -252,6 +264,7 @@ impl SpotifyPlayer {
             oauth_client: Arc::new(RiffOauthClient::new(token_store)),
             auth_challenge: None,
             command_sender,
+            explicit_filter_locked: false,
             delegate,
         }
     }
@@ -421,9 +434,62 @@ impl SpotifyPlayer {
                 tokio::task::spawn(player_setup_delegate(
                     new_player.get_player_event_channel(),
                     self.delegate.clone(),
+                    self.command_sender.clone(),
                 ));
                 self.player.replace(new_player);
 
+                Ok(())
+            }
+            Command::RecheckExplicitFilter => {
+                // Already locked for this session: skipping is forced and
+                // explicit tracks are never attempted, so no need to re-query.
+                if self.explicit_filter_locked {
+                    return Ok(());
+                }
+
+                // Run the profile lookup off the command loop so it never
+                // delays playback commands (e.g. loading the next track). The
+                // result comes back as ExplicitFilterRechecked.
+                let oauth_client = Arc::clone(&self.oauth_client);
+                let command_sender = self.command_sender.clone();
+                tokio::task::spawn(async move {
+                    let token = match oauth_client.get_valid_token().await {
+                        Ok(t) => t,
+                        Err(e) => {
+                            warn!("Explicit filter re-check: could not get token: {e:?}");
+                            return;
+                        }
+                    };
+                    match crate::api::check_user_profile(&token.access_token).await {
+                        Ok(profile) => {
+                            let _ =
+                                command_sender.unbounded_send(Command::ExplicitFilterRechecked {
+                                    filter_enabled: profile.explicit_filter_enabled,
+                                    filter_locked: profile.explicit_filter_locked,
+                                });
+                        }
+                        Err(e) => {
+                            warn!("Failed to re-check explicit content filter: {e:?}");
+                        }
+                    }
+                });
+                Ok(())
+            }
+            Command::ExplicitFilterRechecked {
+                filter_enabled,
+                filter_locked,
+            } => {
+                if filter_locked && !self.explicit_filter_locked {
+                    info!("Explicit content filter is now locked; syncing Riff's filter");
+                }
+                self.explicit_filter_locked = filter_locked;
+                self.delegate.set_explicit_filter_locked(filter_locked);
+                // When the account's filter is enabled (even if not locked),
+                // Spotify's servers reject explicit tracks. Enable client-side
+                // skipping so we never attempt to load them.
+                if filter_enabled {
+                    self.delegate.set_skip_explicit(true);
+                }
                 Ok(())
             }
         }
@@ -436,17 +502,38 @@ impl SpotifyPlayer {
         // Check if the account is premium before connecting to librespot.
         // librespot will crash the process for free accounts, so we must
         // catch this early and report a graceful error instead.
-        match crate::api::check_premium(&credentials.access_token).await {
-            Ok(true) => {}
-            Ok(false) => {
-                warn!("Account is not premium, aborting login");
-                return Err(SpotifyError::NotPremium);
-            }
+        let profile = match crate::api::check_user_profile(&credentials.access_token).await {
+            Ok(p) => p,
             Err(e) => {
-                error!("Premium check failed: {e:?}");
+                error!("User profile check failed: {e:?}");
                 return Err(SpotifyError::LoginFailed);
             }
+        };
+
+        if !profile.is_premium {
+            warn!("Account is not premium, aborting login");
+            return Err(SpotifyError::NotPremium);
         }
+
+        // Sync the explicit content filter from the user's Spotify account.
+        // When filter_enabled is true, Spotify's servers will reject explicit
+        // tracks (returning Unavailable to librespot). We must enable
+        // client-side skipping so Riff never attempts to load those tracks in
+        // the first place - avoiding a cascade of Unavailable rejections that
+        // can disrupt playback of non-explicit tracks too.
+        //
+        // A locked filter (e.g. a family plan parental control) additionally
+        // prevents the user from disabling the skip in Riff's settings.
+        if profile.explicit_filter_enabled {
+            info!("Spotify account has explicit content filter enabled");
+            self.delegate.set_skip_explicit(true);
+        }
+        if profile.explicit_filter_locked {
+            info!("Spotify account explicit content filter is locked");
+        }
+        self.explicit_filter_locked = profile.explicit_filter_locked;
+        self.delegate
+            .set_explicit_filter_locked(profile.explicit_filter_locked);
 
         // Only persist credentials to the keyring after confirming premium status.
         // This prevents non-premium accounts from being saved and retried on next launch.
@@ -467,6 +554,16 @@ impl SpotifyPlayer {
         let username = new_session.username();
         info!("Session created successfully for user: {username}");
 
+        // Disable librespot's built-in explicit content filtering. When the
+        // account has filter_enabled=true, Spotify sets the session attribute
+        // "filter-explicit-content" to "1". This causes the audio key server
+        // to deny decryption keys for ALL tracks (not just explicit ones),
+        // breaking playback entirely. We override it to "0" so librespot can
+        // load any track, and enforce the explicit filter ourselves at the
+        // playback-state level where we only skip tracks actually marked
+        // explicit.
+        new_session.set_user_attribute("filter-explicit-content", "0");
+
         let oauth_client = Arc::clone(&self.oauth_client);
         let session = new_session.clone();
         tokio::task::spawn(async move {
@@ -483,6 +580,7 @@ impl SpotifyPlayer {
         tokio::task::spawn(player_setup_delegate(
             new_player.get_player_event_channel(),
             self.delegate.clone(),
+            self.command_sender.clone(),
         ));
 
         self.player.replace(new_player);
@@ -664,11 +762,27 @@ async fn create_session(
     }
 }
 
-async fn player_setup_delegate(mut channel: PlayerEventChannel, delegate: AppPlayerDelegate) {
+async fn player_setup_delegate(
+    mut channel: PlayerEventChannel,
+    delegate: AppPlayerDelegate,
+    command_sender: UnboundedSender<Command>,
+) {
     while let Some(event) = channel.recv().await {
         match event {
             PlayerEvent::EndOfTrack { .. } => {
                 delegate.end_of_track_reached();
+            }
+            PlayerEvent::Unavailable { track_id, .. } => {
+                warn!(
+                    "Track unavailable (possibly explicit-filtered): {:?}, skipping",
+                    track_id
+                );
+                // Gracefully skip the track that could not be played.
+                delegate.end_of_track_reached();
+                // The account's explicit filter may have changed since login
+                // (e.g. a family plan parental control was just set). Re-query
+                // it so Riff's filter state stays in sync.
+                let _ = command_sender.unbounded_send(Command::RecheckExplicitFilter);
             }
             PlayerEvent::Playing { position_ms, .. } => {
                 delegate.notify_playback_state(position_ms);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -93,6 +93,7 @@ impl SpotifyPlayerSettings {
 
         let volume = settings.double("volume");
         let shuffle = settings.boolean("shuffle");
+        let skip_explicit = settings.boolean("skip-explicit");
         let repeat = match settings.string("repeat").as_str() {
             "song" => RepeatMode::Song,
             "playlist" => RepeatMode::Playlist,
@@ -165,6 +166,8 @@ impl SpotifyPlayerSettings {
             repeat,
             shuffle,
 
+            skip_explicit,
+
             bitrate,
             backend,
             gapless,
@@ -198,6 +201,7 @@ impl SpotifyPlayerSettings {
             SetVolume(self.volume).into(),
             SetShuffled(self.shuffle).into(),
             SetRepeatMode(self.repeat).into(),
+            SetSkipExplicit(self.skip_explicit).into(),
         ]
     }
 }


### PR DESCRIPTION
Adds a "Skip Explicit Tracks" preference that skips tracks marked as explicit during playback (next, previous, and load), and syncs with the Spotify account's explicit content filter.

Resolves https://github.com/Diegovsky/riff/issues/26

