### PR TITLE
Improved mobile experience, new header widget, new dev toggle

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -40,7 +40,7 @@ src/app/components/selection/selection_toolbar.blp
 src/app/components/pages/details_album/release_details.blp
 src/app/components/pages/login/login.blp
 src/app/components/details_page/header.blp
-src/app/components/headerbar/headerbar.blp
+src/app/components/shell/headerbar/headerbar.blp
 src/app/components/device_selector/device_selector.blp
 src/app/components/sidebar/create_playlist.blp
 src/app/components/sidebar/sidebar_row.blp

--- a/src/app/components/mod.rs
+++ b/src/app/components/mod.rs
@@ -42,6 +42,7 @@ pub fn expose_custom_widgets() {
     shell::headerbar::expose_widgets();
     shell::device_selector::expose_widgets();
     widgets::details_page::expose_widgets();
+    shell::window::expose_widgets();
 }
 
 impl dyn ActionDispatcher {

--- a/src/app/components/pages/details_album/model.rs
+++ b/src/app/components/pages/details_album/model.rs
@@ -257,13 +257,6 @@ impl PlaylistModel for DetailsModel {
 }
 
 impl SimpleHeaderBarModel for DetailsModel {
-    fn title(&self) -> Option<String> {
-        None
-    }
-    fn title_updated(&self, _: &AppEvent) -> bool {
-        false
-    }
-
     fn selection_context(&self) -> Option<SelectionContext> {
         if !feature_flags::is_enabled(FeatureFlag::SelectMode) {
             return None;

--- a/src/app/components/pages/details_album/widget.rs
+++ b/src/app/components/pages/details_album/widget.rs
@@ -10,7 +10,7 @@ use super::release_details::ReleaseDetailsDialog;
 use super::DetailsModel;
 
 use crate::app::components::{
-    Component, DetailsPageComponent, EventListener, HasHeaderBarModel, PageModel,
+    Component, DetailsPageComponent, EventListener, HasHeaderBarModel, HeaderRegistrar, PageModel,
 };
 use crate::app::dispatch::Worker;
 use crate::app::AppEvent;
@@ -22,9 +22,19 @@ pub struct Details {
 }
 
 impl Details {
-    pub fn new(model: Rc<DetailsModel>, worker: Worker) -> Self {
-        let mut component =
-            DetailsPageComponent::new(model.clone(), model.to_headerbar_model(), worker);
+    pub fn new(
+        model: Rc<DetailsModel>,
+        worker: Worker,
+        registrar: HeaderRegistrar,
+        name: String,
+    ) -> Self {
+        let mut component = DetailsPageComponent::new(
+            model.clone(),
+            model.to_headerbar_model(),
+            worker,
+            registrar,
+            name,
+        );
         component.create_playlist(None);
 
         let modal = ReleaseDetailsDialog::new();

--- a/src/app/components/pages/details_artist/model.rs
+++ b/src/app/components/pages/details_artist/model.rs
@@ -269,12 +269,6 @@ impl PlaylistModel for ArtistDetailsModel {
 }
 
 impl SimpleHeaderBarModel for ArtistDetailsModel {
-    fn title(&self) -> Option<String> {
-        PageModel::get_title(self)
-    }
-    fn title_updated(&self, event: &AppEvent) -> bool {
-        PageModel::should_refresh_details(self, event)
-    }
     fn selection_context(&self) -> Option<SelectionContext> {
         None
     }

--- a/src/app/components/pages/details_artist/widget.rs
+++ b/src/app/components/pages/details_artist/widget.rs
@@ -10,7 +10,7 @@ use super::ArtistDetailsModel;
 
 use crate::app::components::{
     CardLayout, CardSize, Component, DetailsPageComponent, EventListener, HasHeaderBarModel,
-    SortOrder,
+    HeaderRegistrar, SortOrder,
 };
 use crate::app::{ActionDispatcher, AppEvent, Worker};
 
@@ -26,9 +26,16 @@ impl ArtistDetails {
         shared_layout: Rc<Cell<CardLayout>>,
         shared_size: Rc<Cell<CardSize>>,
         dispatcher: Rc<dyn ActionDispatcher>,
+        registrar: HeaderRegistrar,
+        name: String,
     ) -> Self {
-        let mut component =
-            DetailsPageComponent::new(model.clone(), model.to_headerbar_model(), worker);
+        let mut component = DetailsPageComponent::new(
+            model.clone(),
+            model.to_headerbar_model(),
+            worker,
+            registrar,
+            name,
+        );
         component.create_playlist(Some(&gettext("Top tracks")));
         component.create_embedded_card_list(
             Some(&gettext("Releases")),

--- a/src/app/components/pages/details_playlist/model.rs
+++ b/src/app/components/pages/details_playlist/model.rs
@@ -301,13 +301,6 @@ impl PlaylistModel for PlaylistDetailsModel {
 }
 
 impl SimpleHeaderBarModel for PlaylistDetailsModel {
-    fn title(&self) -> Option<String> {
-        PageModel::get_title(self)
-    }
-    fn title_updated(&self, event: &AppEvent) -> bool {
-        PageModel::should_refresh_details(self, event)
-    }
-
     fn selection_context(&self) -> Option<SelectionContext> {
         if !feature_flags::is_enabled(FeatureFlag::SelectMode) {
             return None;

--- a/src/app/components/pages/details_playlist/widget.rs
+++ b/src/app/components/pages/details_playlist/widget.rs
@@ -6,7 +6,9 @@ use std::rc::Rc;
 
 use super::PlaylistDetailsModel;
 
-use crate::app::components::{Component, DetailsPageComponent, EventListener, HasHeaderBarModel};
+use crate::app::components::{
+    Component, DetailsPageComponent, EventListener, HasHeaderBarModel, HeaderRegistrar,
+};
 use crate::app::dispatch::Worker;
 use crate::app::state::SelectionEvent;
 use crate::app::AppEvent;
@@ -18,9 +20,19 @@ pub struct PlaylistDetails {
 }
 
 impl PlaylistDetails {
-    pub fn new(model: Rc<PlaylistDetailsModel>, worker: Worker) -> Self {
-        let mut component =
-            DetailsPageComponent::new(model.clone(), model.to_headerbar_model(), worker);
+    pub fn new(
+        model: Rc<PlaylistDetailsModel>,
+        worker: Worker,
+        registrar: HeaderRegistrar,
+        name: String,
+    ) -> Self {
+        let mut component = DetailsPageComponent::new(
+            model.clone(),
+            model.to_headerbar_model(),
+            worker,
+            registrar,
+            name,
+        );
         component.create_playlist(None);
 
         Self { model, component }

--- a/src/app/components/pages/details_user/model.rs
+++ b/src/app/components/pages/details_user/model.rs
@@ -151,19 +151,6 @@ impl CardListModel for UserDetailsModel {
 }
 
 impl SimpleHeaderBarModel for UserDetailsModel {
-    fn title(&self) -> Option<String> {
-        Some(format!(
-            "Profile \u{2014} {}",
-            &*self
-                .app_model
-                .map_state_opt(|s| s.browser.user_state(&self.id)?.user.as_ref())?
-        ))
-    }
-
-    fn title_updated(&self, event: &AppEvent) -> bool {
-        PageModel::should_refresh_details(self, event)
-    }
-
     fn selection_context(&self) -> Option<SelectionContext> {
         None
     }

--- a/src/app/components/pages/details_user/widget.rs
+++ b/src/app/components/pages/details_user/widget.rs
@@ -9,7 +9,7 @@ use super::UserDetailsModel;
 
 use crate::app::components::{
     CardLayout, CardSize, Component, DetailsPageComponent, EventListener, HasHeaderBarModel,
-    SortOrder,
+    HeaderRegistrar, SortOrder,
 };
 use crate::app::{ActionDispatcher, AppEvent, Worker};
 
@@ -25,11 +25,18 @@ impl UserDetails {
         shared_layout: Rc<Cell<CardLayout>>,
         shared_size: Rc<Cell<CardSize>>,
         dispatcher: Rc<dyn ActionDispatcher>,
+        registrar: HeaderRegistrar,
+        name: String,
     ) -> Self {
         let model = Rc::new(model);
 
-        let mut component =
-            DetailsPageComponent::new(model.clone(), model.to_headerbar_model(), worker);
+        let mut component = DetailsPageComponent::new(
+            model.clone(),
+            model.to_headerbar_model(),
+            worker,
+            registrar,
+            name,
+        );
         component.create_embedded_card_list(
             Some(&gettext("Public Playlists")),
             "user_playlists",

--- a/src/app/components/pages/now_playing/model.rs
+++ b/src/app/components/pages/now_playing/model.rs
@@ -264,13 +264,6 @@ impl PlaylistModel for NowPlayingModel {
 }
 
 impl SimpleHeaderBarModel for NowPlayingModel {
-    fn title(&self) -> Option<String> {
-        Some(gettext("Now Playing"))
-    }
-    fn title_updated(&self, _: &AppEvent) -> bool {
-        false
-    }
-
     fn selection_context(&self) -> Option<SelectionContext> {
         if !feature_flags::is_enabled(FeatureFlag::SelectMode) {
             return None;

--- a/src/app/components/pages/now_playing/widget.rs
+++ b/src/app/components/pages/now_playing/widget.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use super::NowPlayingModel;
 use crate::app::components::{
     Component, DetailsPageComponent, DeviceSelector, DeviceSelectorWidget, EventListener,
-    HasHeaderBarModel, PlaylistModel,
+    HasHeaderBarModel, HeaderRegistrar, PlaylistModel,
 };
 use crate::app::dispatch::Worker;
 use crate::app::state::PlaybackEvent;
@@ -25,16 +25,24 @@ pub struct NowPlaying {
 }
 
 impl NowPlaying {
-    pub fn new(model: Rc<NowPlayingModel>, worker: Worker) -> Self {
-        let mut component =
-            DetailsPageComponent::new(model.clone(), model.to_headerbar_model(), worker);
+    pub fn new(
+        model: Rc<NowPlayingModel>,
+        worker: Worker,
+        registrar: HeaderRegistrar,
+        name: String,
+    ) -> Self {
+        let mut component = DetailsPageComponent::new(
+            model.clone(),
+            model.to_headerbar_model(),
+            worker,
+            registrar,
+            name,
+        );
         component.create_playlist(Some(&gettext("Queue")));
 
         if feature_flags::is_enabled(FeatureFlag::DeviceSelector) {
             let ds_widget: DeviceSelectorWidget = glib::Object::new();
-            if let Some(hb) = component.page().headerbar() {
-                hb.pack_end(&ds_widget);
-            }
+            component.add_header_end(&ds_widget);
             let device_selector = Box::new(DeviceSelector::new(
                 ds_widget,
                 model.device_selector_model(),

--- a/src/app/components/pages/saved_tracks/model.rs
+++ b/src/app/components/pages/saved_tracks/model.rs
@@ -193,13 +193,6 @@ impl PlaylistModel for SavedTracksModel {
 }
 
 impl SimpleHeaderBarModel for SavedTracksModel {
-    fn title(&self) -> Option<String> {
-        Some(gettext("All Tracks"))
-    }
-    fn title_updated(&self, _: &AppEvent) -> bool {
-        false
-    }
-
     fn selection_context(&self) -> Option<SelectionContext> {
         if !feature_flags::is_enabled(FeatureFlag::SelectMode) {
             return None;

--- a/src/app/components/pages/saved_tracks/widget.rs
+++ b/src/app/components/pages/saved_tracks/widget.rs
@@ -4,7 +4,9 @@
 use std::rc::Rc;
 
 use super::SavedTracksModel;
-use crate::app::components::{Component, DetailsPageComponent, EventListener, HasHeaderBarModel};
+use crate::app::components::{
+    Component, DetailsPageComponent, EventListener, HasHeaderBarModel, HeaderRegistrar,
+};
 use crate::app::state::LoginEvent;
 use crate::app::{AppEvent, Worker};
 
@@ -15,9 +17,19 @@ pub struct SavedTracks {
 }
 
 impl SavedTracks {
-    pub fn new(model: Rc<SavedTracksModel>, worker: Worker) -> Self {
-        let mut component =
-            DetailsPageComponent::new(model.clone(), model.to_headerbar_model(), worker);
+    pub fn new(
+        model: Rc<SavedTracksModel>,
+        worker: Worker,
+        registrar: HeaderRegistrar,
+        name: String,
+    ) -> Self {
+        let mut component = DetailsPageComponent::new(
+            model.clone(),
+            model.to_headerbar_model(),
+            worker,
+            registrar,
+            name,
+        );
         component.create_playlist(None);
 
         Self { model, component }

--- a/src/app/components/pages/search/search.blp
+++ b/src/app/components/pages/search/search.blp
@@ -5,107 +5,92 @@ template $SearchResultsWidget : Box {
   orientation: vertical;
   can-focus: true;
 
-  Adw.HeaderBar main_header {
-    show-end-title-buttons: true;
-    show-back-button: false;
+  Adw.Clamp search_bar {
+    maximum-size: 740;
+    hexpand: true;
 
-    Button go_back {
-      halign: start;
-      valign: center;
-      icon-name: "go-previous-symbolic";
-      has-frame: false;
-      focus-on-click: false;
-      can-focus: false;
-    }
+    child: Box search_box {
+      orientation: horizontal;
+      spacing: 0;
 
-    [title]
-    Adw.Clamp {
-      maximum-size: 740;
-      hexpand: true;
+      styles [
+        "linked",
+        "search-bar-container",
+      ]
 
-      child: Box search_box {
-        orientation: horizontal;
-        spacing: 0;
+      SearchEntry search_entry {
+        hexpand: true;
+        receives-default: true;
+        can-focus: true;
+      }
 
-        styles [
-          "linked",
-          "search-bar-container",
-        ]
+      MenuButton filter_button {
+        icon-name: "nautilus-search-filters-symbolic";
+        tooltip-text: _("Filter");
+        focus-on-click: false;
+        can-focus: false;
 
-        SearchEntry search_entry {
-          hexpand: true;
-          receives-default: true;
-          can-focus: true;
-        }
+        popover: Popover filter_popover {
+          child: Box {
+            orientation: vertical;
+            spacing: 12;
+            margin-start: 12;
+            margin-end: 12;
+            margin-top: 12;
+            margin-bottom: 12;
 
-        MenuButton filter_button {
-          icon-name: "nautilus-search-filters-symbolic";
-          tooltip-text: _("Filter");
-          focus-on-click: false;
-          can-focus: false;
+            Label {
+              label: _("Filter by type");
+              hexpand: true;
+              xalign: 0;
+              valign: baseline;
 
-          popover: Popover filter_popover {
-            child: Box {
-              orientation: vertical;
-              spacing: 12;
-              margin-start: 12;
-              margin-end: 12;
-              margin-top: 12;
-              margin-bottom: 12;
+              styles [
+                "heading",
+              ]
+            }
 
-              Label {
-                label: _("Filter by type");
-                hexpand: true;
-                xalign: 0;
-                valign: baseline;
+            Adw.WrapBox {
+              child-spacing: 6;
+              line-spacing: 6;
+              natural-line-length: 300;
 
-                styles [
-                  "heading",
-                ]
+              ToggleButton filter_artists {
+                child: Adw.ButtonContent {
+                  icon-name: "avatar-default-symbolic";
+                  label: _("_Artist");
+                  use-underline: true;
+                };
               }
 
-              Adw.WrapBox {
-                child-spacing: 6;
-                line-spacing: 6;
-                natural-line-length: 300;
-
-                ToggleButton filter_artists {
-                  child: Adw.ButtonContent {
-                    icon-name: "avatar-default-symbolic";
-                    label: _("_Artist");
-                    use-underline: true;
-                  };
-                }
-
-                ToggleButton filter_albums {
-                  child: Adw.ButtonContent {
-                    icon-name: "library-music-symbolic";
-                    label: _("_Albums");
-                    use-underline: true;
-                  };
-                }
-
-                ToggleButton filter_playlists {
-                  child: Adw.ButtonContent {
-                    icon-name: "playlist2-symbolic";
-                    label: _("_Playlists");
-                    use-underline: true;
-                  };
-                }
-
-                ToggleButton filter_songs {
-                  child: Adw.ButtonContent {
-                    icon-name: "audio-x-generic-symbolic";
-                    label: _("_Tracks");
-                    use-underline: true;
-                  };
-                }
+              ToggleButton filter_albums {
+                child: Adw.ButtonContent {
+                  icon-name: "library-music-symbolic";
+                  label: _("_Albums");
+                  use-underline: true;
+                };
               }
-            };
+
+              ToggleButton filter_playlists {
+                child: Adw.ButtonContent {
+                  icon-name: "playlist2-symbolic";
+                  label: _("_Playlists");
+                  use-underline: true;
+                };
+              }
+
+              ToggleButton filter_songs {
+                child: Adw.ButtonContent {
+                  icon-name: "audio-x-generic-symbolic";
+                  label: _("_Tracks");
+                  use-underline: true;
+                };
+              }
+            }
           };
-        }
-      };
-    }
+        };
+      }
+    };
   }
 
   Overlay overlay {

--- a/src/app/components/pages/search/search.rs
+++ b/src/app/components/pages/search/search.rs
@@ -9,7 +9,7 @@ use crate::app::components::utils::Debouncer;
 use crate::app::components::widgets::card_list::card_view_menu::CardViewMenu;
 use crate::app::components::{
     display_add_css_provider, CardLayout, CardList, CardListModel, CardSize, CardWidget, Component,
-    EventListener, ImageShape, Playlist, SortOrder, CLAMP_MAX_SIZE,
+    EventListener, HeaderRegistrar, ImageShape, Playlist, SortOrder, CLAMP_MAX_SIZE,
 };
 use crate::app::dispatch::Worker;
 use crate::app::models::{CardModel, SearchType, SongDescription};
@@ -41,10 +41,7 @@ mod imp {
     #[template(resource = "/dev/diegovsky/Riff/components/search.ui")]
     pub struct SearchResultsWidget {
         #[template_child]
-        pub main_header: TemplateChild<libadwaita::HeaderBar>,
-
-        #[template_child]
-        pub go_back: TemplateChild<gtk::Button>,
+        pub search_bar: TemplateChild<libadwaita::Clamp>,
 
         #[template_child]
         pub search_entry: TemplateChild<gtk::SearchEntry>,
@@ -118,13 +115,6 @@ impl Default for SearchResultsWidget {
 impl SearchResultsWidget {
     pub fn new() -> Self {
         glib::Object::new()
-    }
-
-    pub fn connect_go_back<F>(&self, f: F)
-    where
-        F: Fn() + 'static,
-    {
-        self.imp().go_back.connect_clicked(move |_| f());
     }
 
     pub fn connect_search_updated<F>(&self, f: F)
@@ -330,6 +320,7 @@ pub struct SearchResults {
     worker: Worker,
     debouncer: Debouncer,
     children: Vec<Box<dyn EventListener>>,
+    registrar: HeaderRegistrar,
 }
 
 impl SearchResults {
@@ -339,11 +330,17 @@ impl SearchResults {
         layout: Rc<Cell<CardLayout>>,
         size: Rc<Cell<CardSize>>,
         dispatcher: Rc<dyn ActionDispatcher>,
+        registrar: HeaderRegistrar,
     ) -> Self {
         display_add_css_provider(resource!("/components/search.css"));
 
         let model = Rc::new(model);
         let widget = SearchResultsWidget::new();
+
+        // Move the search bar into the shared header as this screen's title.
+        let search_bar = widget.imp().search_bar.get();
+        widget.remove(&search_bar);
+        registrar.add_title("search", &search_bar);
 
         // --- Combined ("all") view: Tracks / Artists / Albums sections ---
         let all_box = gtk::Box::new(gtk::Orientation::Vertical, SECTION_SPACING);
@@ -509,13 +506,7 @@ impl SearchResults {
             Rc::clone(&track_card_list),
             Rc::clone(&dispatcher),
         );
-        widget.imp().main_header.pack_end(view_menu.widget());
-
-        widget.connect_go_back(clone!(
-            #[weak]
-            model,
-            move || model.go_back()
-        ));
+        registrar.add_end("search", view_menu.widget());
 
         widget.connect_search_updated(clone!(
             #[weak]
@@ -566,6 +557,7 @@ impl SearchResults {
             worker,
             debouncer: Debouncer::new(),
             children: vec![Box::new(scope_playlist)],
+            registrar,
         }
     }
 
@@ -660,6 +652,12 @@ impl SearchResults {
         if !matches!(self.model.get_filter(), Some(SearchType::Tracks)) {
             self.scope_card_list.remove_placeholders();
         }
+    }
+}
+
+impl Drop for SearchResults {
+    fn drop(&mut self) {
+        self.registrar.remove("search");
     }
 }
 

--- a/src/app/components/pages/search/search_model.rs
+++ b/src/app/components/pages/search/search_model.rs
@@ -30,11 +30,6 @@ impl SearchResultsModel {
         Rc::clone(&self.app_model)
     }
 
-    pub fn go_back(&self) {
-        self.dispatcher
-            .dispatch(BrowserAction::NavigationPop.into());
-    }
-
     pub fn search(&self, query: String) {
         self.dispatcher
             .dispatch(BrowserAction::Search(query).into());

--- a/src/app/components/shell/headerbar/component.rs
+++ b/src/app/components/shell/headerbar/component.rs
@@ -1,117 +1,41 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
-use gtk::prelude::*;
+use glib::clone;
 
-use crate::app::{
-    components::{Component, EventListener, ListenerComponent},
-    state::{SelectionContext, SelectionEvent},
-    ActionDispatcher, AppAction, AppEvent, AppModel, BrowserAction, BrowserEvent,
-};
+use crate::app::components::EventListener;
+use crate::app::state::{SelectionContext, SelectionEvent};
+use crate::app::{ActionDispatcher, AppAction, AppEvent, AppModel, BrowserAction, BrowserEvent};
 
-use super::widget::HeaderBarWidget;
+use super::widget::AppHeaderBar;
 
+/// Selection behavior the shared header needs from the active screen.
+/// Back and title are handled by the header itself.
 pub trait HeaderBarModel {
-    fn title(&self) -> Option<String>;
-    fn title_updated(&self, event: &AppEvent) -> bool;
-    fn go_back(&self);
-    fn can_go_back(&self) -> bool;
     fn selection_context(&self) -> Option<SelectionContext>;
     fn can_select_all(&self) -> bool;
     fn start_selection(&self);
     fn select_all(&self);
     fn cancel_selection(&self);
-    fn selected_count(&self) -> usize;
 }
 
-pub struct DefaultHeaderBarModel {
-    title: Option<String>,
-    selection_context: Option<SelectionContext>,
-    app_model: Rc<AppModel>,
-    dispatcher: Box<dyn ActionDispatcher>,
-}
-
-impl DefaultHeaderBarModel {
-    pub fn new(
-        title: Option<String>,
-        selection_context: Option<SelectionContext>,
-        app_model: Rc<AppModel>,
-        dispatcher: Box<dyn ActionDispatcher>,
-    ) -> Self {
-        Self {
-            title,
-            selection_context,
-            app_model,
-            dispatcher,
-        }
-    }
-}
-
-impl HeaderBarModel for DefaultHeaderBarModel {
-    fn title(&self) -> Option<String> {
-        self.title.clone()
-    }
-
-    fn title_updated(&self, _: &AppEvent) -> bool {
-        false
-    }
-
-    fn go_back(&self) {
-        self.dispatcher
-            .dispatch(BrowserAction::NavigationPop.into())
-    }
-
-    fn can_go_back(&self) -> bool {
-        self.app_model.get_state().browser.can_pop()
-    }
-
-    fn selection_context(&self) -> Option<SelectionContext> {
-        self.selection_context.clone()
-    }
-
-    fn can_select_all(&self) -> bool {
-        false
-    }
-
-    fn start_selection(&self) {
-        if let Some(context) = self.selection_context.as_ref() {
-            self.dispatcher
-                .dispatch(AppAction::EnableSelection(context.clone()))
-        }
-    }
-
-    fn select_all(&self) {}
-
-    fn cancel_selection(&self) {
-        self.dispatcher.dispatch(AppAction::CancelSelection)
-    }
-
-    fn selected_count(&self) -> usize {
-        self.app_model.get_state().selection.count()
-    }
-}
-
+/// Per-screen selection hooks, wrapped into a [`HeaderBarModel`] by
+/// [`SimpleHeaderBarModelWrapper`].
 pub trait SimpleHeaderBarModel {
-    fn title(&self) -> Option<String>;
-    fn title_updated(&self, event: &AppEvent) -> bool;
     fn selection_context(&self) -> Option<SelectionContext>;
     fn select_all(&self);
 }
 
 pub struct SimpleHeaderBarModelWrapper<M> {
     wrapped_model: Rc<M>,
-    app_model: Rc<AppModel>,
     dispatcher: Box<dyn ActionDispatcher>,
 }
 
 impl<M> SimpleHeaderBarModelWrapper<M> {
-    pub fn new(
-        wrapped_model: Rc<M>,
-        app_model: Rc<AppModel>,
-        dispatcher: Box<dyn ActionDispatcher>,
-    ) -> Self {
+    pub fn new(wrapped_model: Rc<M>, dispatcher: Box<dyn ActionDispatcher>) -> Self {
         Self {
             wrapped_model,
-            app_model,
             dispatcher,
         }
     }
@@ -121,23 +45,6 @@ impl<M> HeaderBarModel for SimpleHeaderBarModelWrapper<M>
 where
     M: SimpleHeaderBarModel + 'static,
 {
-    fn title(&self) -> Option<String> {
-        self.wrapped_model.title()
-    }
-
-    fn title_updated(&self, event: &AppEvent) -> bool {
-        self.wrapped_model.title_updated(event)
-    }
-
-    fn go_back(&self) {
-        self.dispatcher
-            .dispatch(BrowserAction::NavigationPop.into())
-    }
-
-    fn can_go_back(&self) -> bool {
-        self.app_model.get_state().browser.can_pop()
-    }
-
     fn selection_context(&self) -> Option<SelectionContext> {
         self.wrapped_model.selection_context()
     }
@@ -160,151 +67,173 @@ where
     fn cancel_selection(&self) {
         self.dispatcher.dispatch(AppAction::CancelSelection)
     }
+}
 
-    fn selected_count(&self) -> usize {
-        self.app_model.get_state().selection.count()
+/// Maps a header page name (see [`resolve_active_page`]) to the
+/// [`HeaderBarModel`] for that screen. Screens populate it as they are built;
+/// [`AppHeaderBarComponent`] reads it to rebind the header on screen changes.
+pub type HeaderModelRegistry = Rc<RefCell<HashMap<String, Rc<dyn HeaderBarModel>>>>;
+
+/// Home sub-page shown before the first [`BrowserEvent::HomeVisiblePageChanged`].
+const DEFAULT_HOME_PAGE: &str = "library";
+
+/// Resolve which header page is active. The "home" screen hosts several
+/// sub-pages, so it follows the visible home sub-page; any other screen maps
+/// to its own identifier.
+fn resolve_active_page<'a>(current_screen: &'a str, home_page: &'a str) -> &'a str {
+    if current_screen == "home" {
+        home_page
+    } else {
+        current_screen
     }
 }
 
-mod common {
+/// Owns the app-wide header bar, swapping its title/button pages and
+/// selection/back behavior when the active screen changes.
+pub struct AppHeaderBarComponent {
+    widget: AppHeaderBar,
+    app_model: Rc<AppModel>,
+    models: HeaderModelRegistry,
+    active_model: Rc<RefCell<Option<Rc<dyn HeaderBarModel>>>>,
+    home_page: String,
+}
 
-    use super::*;
+impl AppHeaderBarComponent {
+    pub fn new(
+        widget: AppHeaderBar,
+        app_model: Rc<AppModel>,
+        dispatcher: Box<dyn ActionDispatcher>,
+        models: HeaderModelRegistry,
+    ) -> Self {
+        let active_model: Rc<RefCell<Option<Rc<dyn HeaderBarModel>>>> = Rc::new(RefCell::new(None));
 
-    pub fn update_for_event<Model>(event: &AppEvent, widget: &HeaderBarWidget, model: &Rc<Model>)
-    where
-        Model: HeaderBarModel + 'static,
-    {
+        // Back navigates the browser stack.
+        widget.connect_go_back(move || dispatcher.dispatch(BrowserAction::NavigationPop.into()));
+
+        // Selection controls route to the active screen.
+        widget.connect_selection_start(clone!(
+            #[strong]
+            active_model,
+            move || {
+                if let Some(model) = active_model.borrow().as_ref() {
+                    model.start_selection();
+                }
+            }
+        ));
+        widget.connect_select_all(clone!(
+            #[strong]
+            active_model,
+            move || {
+                if let Some(model) = active_model.borrow().as_ref() {
+                    model.select_all();
+                }
+            }
+        ));
+        widget.connect_selection_cancel(clone!(
+            #[strong]
+            active_model,
+            move || {
+                if let Some(model) = active_model.borrow().as_ref() {
+                    model.cancel_selection();
+                }
+            }
+        ));
+
+        Self {
+            widget,
+            app_model,
+            models,
+            active_model,
+            home_page: DEFAULT_HOME_PAGE.to_string(),
+        }
+    }
+
+    fn current_screen_id(&self) -> String {
+        self.app_model
+            .get_state()
+            .browser
+            .current_screen()
+            .identifier()
+            .into_owned()
+    }
+
+    /// Recompute the active page and rebind the header's stacks and state.
+    fn refresh_active(&self) {
+        let current = self.current_screen_id();
+        let active = resolve_active_page(&current, &self.home_page).to_string();
+
+        self.widget.set_active(&active);
+
+        let model = self.models.borrow().get(&active).cloned();
+        if let Some(ref model) = model {
+            self.widget
+                .set_selection_possible(model.selection_context().is_some());
+            self.widget.set_select_all_possible(model.can_select_all());
+        } else {
+            self.widget.set_selection_possible(false);
+            self.widget.set_select_all_possible(false);
+        }
+        *self.active_model.borrow_mut() = model;
+
+        self.widget
+            .set_can_go_back(self.app_model.get_state().browser.can_pop());
+    }
+
+    fn cancel_active_selection(&self) {
+        let model = self.active_model.borrow().clone();
+        if let Some(model) = model {
+            model.cancel_selection();
+        }
+    }
+}
+
+impl EventListener for AppHeaderBarComponent {
+    fn on_event(&mut self, event: &AppEvent) {
         match event {
+            AppEvent::Started => self.refresh_active(),
+            AppEvent::BrowserEvent(
+                BrowserEvent::NavigationPushed(_)
+                | BrowserEvent::NavigationPopped
+                | BrowserEvent::NavigationPoppedTo(_)
+                | BrowserEvent::NavigationHidden(_),
+            ) => {
+                self.cancel_active_selection();
+                self.refresh_active();
+            }
+            AppEvent::BrowserEvent(BrowserEvent::HomeVisiblePageChanged(page)) => {
+                self.home_page = (*page).to_string();
+                self.refresh_active();
+            }
             AppEvent::SelectionEvent(SelectionEvent::SelectionModeChanged(active)) => {
-                widget.set_selection_active(*active);
+                self.widget.set_selection_active(*active);
             }
             AppEvent::SelectionEvent(SelectionEvent::SelectionChanged) => {
-                widget.set_selection_count(model.selected_count());
-            }
-            AppEvent::BrowserEvent(BrowserEvent::NavigationPushed(_))
-            | AppEvent::BrowserEvent(BrowserEvent::NavigationPoppedTo(_))
-            | AppEvent::BrowserEvent(BrowserEvent::NavigationPopped)
-            | AppEvent::BrowserEvent(BrowserEvent::NavigationHidden(_)) => {
-                model.cancel_selection();
-                widget.set_can_go_back(model.can_go_back());
-            }
-            event if model.title_updated(event) => {
-                widget.set_title(model.title().as_ref().map(|s| &s[..]));
+                let count = self.app_model.get_state().selection.count();
+                self.widget.set_selection_count(count);
             }
             _ => {}
         }
     }
-
-    pub fn bind_headerbar<Model>(widget: &HeaderBarWidget, model: &Rc<Model>)
-    where
-        Model: HeaderBarModel + 'static,
-    {
-        widget.connect_selection_start(clone!(
-            #[weak]
-            model,
-            move || model.start_selection()
-        ));
-        widget.connect_select_all(clone!(
-            #[weak]
-            model,
-            move || model.select_all()
-        ));
-        widget.connect_selection_cancel(clone!(
-            #[weak]
-            model,
-            move || model.cancel_selection()
-        ));
-        widget.connect_go_back(clone!(
-            #[weak]
-            model,
-            move || model.go_back()
-        ));
-
-        widget.set_title(model.title().as_ref().map(|s| &s[..]));
-        widget.set_selection_possible(model.selection_context().is_some());
-        widget.set_select_all_possible(model.can_select_all());
-        widget.set_can_go_back(model.can_go_back());
-    }
 }
 
-pub struct HeaderBarComponent<Model: HeaderBarModel> {
-    widget: HeaderBarWidget,
-    model: Rc<Model>,
-}
+#[cfg(test)]
+mod tests {
+    use super::resolve_active_page;
 
-impl<Model> HeaderBarComponent<Model>
-where
-    Model: HeaderBarModel + 'static,
-{
-    pub fn new(widget: HeaderBarWidget, model: Rc<Model>) -> Self {
-        common::bind_headerbar(&widget, &model);
-        Self { widget, model }
-    }
-}
-
-impl<Model> EventListener for HeaderBarComponent<Model>
-where
-    Model: HeaderBarModel + 'static,
-{
-    fn on_event(&mut self, event: &AppEvent) {
-        common::update_for_event(event, &self.widget, &self.model);
-    }
-}
-
-// wrapper version ("Screen")
-pub struct StandardScreen<Model: HeaderBarModel> {
-    root: gtk::Widget,
-    widget: HeaderBarWidget,
-    model: Rc<Model>,
-    children: Vec<Box<dyn EventListener>>,
-}
-
-impl<Model> StandardScreen<Model>
-where
-    Model: HeaderBarModel + 'static,
-{
-    pub fn new(wrapped: impl ListenerComponent + 'static, model: Rc<Model>) -> Self {
-        let widget = HeaderBarWidget::new();
-        common::bind_headerbar(&widget, &model);
-
-        let root = gtk::Box::builder()
-            .orientation(gtk::Orientation::Vertical)
-            .build();
-        root.append(&widget);
-        root.append(wrapped.get_root_widget());
-
-        Self {
-            root: root.upcast(),
-            widget,
-            model,
-            children: vec![Box::new(wrapped)],
-        }
+    #[test]
+    fn home_screen_follows_home_sub_page() {
+        assert_eq!(resolve_active_page("home", "library"), "library");
+        assert_eq!(resolve_active_page("home", "saved_tracks"), "saved_tracks");
+        assert_eq!(resolve_active_page("home", "now_playing"), "now_playing");
     }
 
-    pub fn headerbar(&self) -> &HeaderBarWidget {
-        &self.widget
-    }
-}
-
-impl<Model> Component for StandardScreen<Model>
-where
-    Model: HeaderBarModel + 'static,
-{
-    fn get_root_widget(&self) -> &gtk::Widget {
-        &self.root
-    }
-
-    fn get_children(&mut self) -> Option<&mut Vec<Box<dyn EventListener>>> {
-        Some(&mut self.children)
-    }
-}
-
-impl<Model> EventListener for StandardScreen<Model>
-where
-    Model: HeaderBarModel + 'static,
-{
-    fn on_event(&mut self, event: &AppEvent) {
-        common::update_for_event(event, &self.widget, &self.model);
-        self.broadcast_event(event);
+    #[test]
+    fn pushed_screen_maps_to_itself() {
+        assert_eq!(resolve_active_page("album_123", "library"), "album_123");
+        assert_eq!(resolve_active_page("search", "saved_tracks"), "search");
+        assert_eq!(
+            resolve_active_page("artist_abc", "now_playing"),
+            "artist_abc"
+        );
     }
 }

--- a/src/app/components/shell/headerbar/headerbar.blp
+++ b/src/app/components/shell/headerbar/headerbar.blp
@@ -1,14 +1,31 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $HeaderBarWidget : Adw.Bin {
-  [root]
+template $AppHeaderBar : Adw.Bin {
   Overlay overlay {
     hexpand: true;
 
     Adw.HeaderBar main_header {
       show-end-title-buttons: true;
       show-back-button: false;
+
+      // Flat: no background or separator, so the header blends into the content.
+      styles [
+        "flat",
+      ]
+
+      ToggleButton sidebar_toggle {
+        halign: start;
+        valign: center;
+        icon-name: "sidebar-show-symbolic";
+        action-name: "win.show-sidebar";
+        focus-on-click: false;
+        can-focus: false;
+
+        /* Translators: Tooltip for the button that shows/hides the sidebar. */
+
+        tooltip-text: _("Toggle Sidebar");
+      }
 
       Button go_back {
         receives-default: true;
@@ -18,12 +35,17 @@ template $HeaderBarWidget : Adw.Bin {
         has-frame: false;
         focus-on-click: false;
         can-focus: false;
+        visible: false;
+
+        /* Translators: Tooltip for the header bar button that navigates back. */
+
+        tooltip-text: _("Back");
       }
 
       [title]
-      Adw.WindowTitle title {
-        visible: true;
-        title: "RIff";
+      Stack title_stack {
+        hexpand: true;
+        hhomogeneous: false;
       }
 
       [end]
@@ -31,6 +53,12 @@ template $HeaderBarWidget : Adw.Bin {
         icon-name: "object-select-symbolic";
         focus-on-click: false;
         can-focus: false;
+        visible: false;
+      }
+
+      [end]
+      Stack end_stack {
+        hhomogeneous: false;
       }
     }
 

--- a/src/app/components/shell/headerbar/mod.rs
+++ b/src/app/components/shell/headerbar/mod.rs
@@ -4,8 +4,11 @@ pub use widget::*;
 mod component;
 pub use component::*;
 
+mod registrar;
+pub use registrar::*;
+
 use glib::prelude::*;
 
 pub fn expose_widgets() {
-    widget::HeaderBarWidget::static_type();
+    widget::AppHeaderBar::static_type();
 }

--- a/src/app/components/shell/headerbar/registrar.rs
+++ b/src/app/components/shell/headerbar/registrar.rs
@@ -1,0 +1,57 @@
+use std::rc::Rc;
+
+use gtk::prelude::*;
+
+use super::component::{HeaderBarModel, HeaderModelRegistry};
+use super::widget::AppHeaderBar;
+
+/// Handle screens use to contribute to the shared [`AppHeaderBar`]: a title
+/// widget, optional end buttons, and the [`HeaderBarModel`] driving
+/// selection/back. Each contribution is keyed by the screen's page name.
+#[derive(Clone)]
+pub struct HeaderRegistrar {
+    widget: AppHeaderBar,
+    models: HeaderModelRegistry,
+}
+
+impl HeaderRegistrar {
+    pub fn new(widget: AppHeaderBar, models: HeaderModelRegistry) -> Self {
+        Self { widget, models }
+    }
+
+    /// Register a fixed-text title for `name`.
+    pub fn set_static_title(&self, name: &str, title: &str) {
+        let window_title = libadwaita::WindowTitle::new(title, "");
+        self.widget.add_title(name, &window_title);
+    }
+
+    /// Register (and return) a title widget for `name` whose content and
+    /// visibility the caller controls (used by detail pages to reveal the
+    /// title on scroll).
+    pub fn add_title_widget(&self, name: &str) -> libadwaita::WindowTitle {
+        let window_title = libadwaita::WindowTitle::new("", "");
+        self.widget.add_title(name, &window_title);
+        window_title
+    }
+
+    /// Register a widget in the optional-buttons (end) area for `name`.
+    pub fn add_end(&self, name: &str, widget: &impl IsA<gtk::Widget>) {
+        self.widget.add_end(name, widget);
+    }
+
+    /// Register a caller-provided widget as the title for `name`.
+    pub fn add_title(&self, name: &str, widget: &impl IsA<gtk::Widget>) {
+        self.widget.add_title(name, widget);
+    }
+
+    /// Register the [`HeaderBarModel`] driving selection/back for `name`.
+    pub fn register_model(&self, name: &str, model: Rc<dyn HeaderBarModel>) {
+        self.models.borrow_mut().insert(name.to_string(), model);
+    }
+
+    /// Remove every contribution registered under `name`.
+    pub fn remove(&self, name: &str) {
+        self.widget.remove_page(name);
+        self.models.borrow_mut().remove(name);
+    }
+}

--- a/src/app/components/shell/headerbar/widget.rs
+++ b/src/app/components/shell/headerbar/widget.rs
@@ -11,41 +11,40 @@ mod imp {
 
     #[derive(Debug, Default, CompositeTemplate)]
     #[template(resource = "/dev/diegovsky/Riff/components/headerbar.ui")]
-    pub struct HeaderBarWidget {
+    pub struct AppHeaderBar {
         #[template_child]
-        pub main_header: TemplateChild<libadwaita::HeaderBar>,
-
-        #[template_child]
-        pub selection_header: TemplateChild<libadwaita::HeaderBar>,
+        pub sidebar_toggle: TemplateChild<gtk::ToggleButton>,
 
         #[template_child]
         pub go_back: TemplateChild<gtk::Button>,
 
         #[template_child]
-        pub title: TemplateChild<libadwaita::WindowTitle>,
+        pub title_stack: TemplateChild<gtk::Stack>,
 
         #[template_child]
-        pub selection_title: TemplateChild<libadwaita::WindowTitle>,
+        pub end_stack: TemplateChild<gtk::Stack>,
 
         #[template_child]
         pub start_selection: TemplateChild<gtk::Button>,
+
+        #[template_child]
+        pub selection_header: TemplateChild<libadwaita::HeaderBar>,
+
+        #[template_child]
+        pub selection_title: TemplateChild<libadwaita::WindowTitle>,
 
         #[template_child]
         pub select_all: TemplateChild<gtk::Button>,
 
         #[template_child]
         pub cancel: TemplateChild<gtk::Button>,
-
-        #[template_child]
-        pub overlay: TemplateChild<gtk::Overlay>,
     }
 
     #[glib::object_subclass]
-    impl ObjectSubclass for HeaderBarWidget {
-        const NAME: &'static str = "HeaderBarWidget";
-        type Type = super::HeaderBarWidget;
+    impl ObjectSubclass for AppHeaderBar {
+        const NAME: &'static str = "AppHeaderBar";
+        type Type = super::AppHeaderBar;
         type ParentType = libadwaita::Bin;
-        type Interfaces = (gtk::Buildable,);
 
         fn class_init(klass: &mut Self::Class) {
             klass.bind_template();
@@ -56,66 +55,87 @@ mod imp {
         }
     }
 
-    impl ObjectImpl for HeaderBarWidget {}
-
-    impl BuildableImpl for HeaderBarWidget {
-        fn add_child(&self, builder: &gtk::Builder, child: &glib::Object, type_: Option<&str>) {
-            if Some("root") == type_ {
-                self.parent_add_child(builder, child, type_);
-            } else {
-                self.main_header
-                    .set_title_widget(child.downcast_ref::<gtk::Widget>());
-            }
-        }
-    }
-
-    impl WidgetImpl for HeaderBarWidget {}
-    impl BinImpl for HeaderBarWidget {}
-    impl WindowImpl for HeaderBarWidget {}
+    impl ObjectImpl for AppHeaderBar {}
+    impl WidgetImpl for AppHeaderBar {}
+    impl BinImpl for AppHeaderBar {}
 }
 
 glib::wrapper! {
-    pub struct HeaderBarWidget(ObjectSubclass<imp::HeaderBarWidget>) @extends gtk::Widget, libadwaita::Bin;
+    pub struct AppHeaderBar(ObjectSubclass<imp::AppHeaderBar>) @extends gtk::Widget, libadwaita::Bin;
 }
 
-impl Default for HeaderBarWidget {
+impl Default for AppHeaderBar {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl HeaderBarWidget {
+impl AppHeaderBar {
     pub fn new() -> Self {
         glib::Object::new()
     }
 
-    pub fn connect_selection_start<F>(&self, f: F)
-    where
-        F: Fn() + 'static,
-    {
+    // --- Per-screen page registration ---
+
+    /// Register a title-area widget for `name`. No-op if one already exists.
+    pub fn add_title(&self, name: &str, widget: &impl IsA<gtk::Widget>) {
+        let stack = &self.imp().title_stack;
+        if stack.child_by_name(name).is_none() {
+            stack.add_named(widget, Some(name));
+        }
+    }
+
+    /// Register an end-area widget for `name`. No-op if one already exists.
+    pub fn add_end(&self, name: &str, widget: &impl IsA<gtk::Widget>) {
+        let stack = &self.imp().end_stack;
+        if stack.child_by_name(name).is_none() {
+            stack.add_named(widget, Some(name));
+        }
+    }
+
+    /// Remove any title and end pages registered under `name`.
+    pub fn remove_page(&self, name: &str) {
+        if let Some(child) = self.imp().title_stack.child_by_name(name) {
+            self.imp().title_stack.remove(&child);
+        }
+        if let Some(child) = self.imp().end_stack.child_by_name(name) {
+            self.imp().end_stack.remove(&child);
+        }
+    }
+
+    /// Show the title and end pages for `name`; hide the end area if none.
+    pub fn set_active(&self, name: &str) {
+        let imp = self.imp();
+        if imp.title_stack.child_by_name(name).is_some() {
+            imp.title_stack.set_visible_child_name(name);
+        }
+        if imp.end_stack.child_by_name(name).is_some() {
+            imp.end_stack.set_visible_child_name(name);
+            imp.end_stack.set_visible(true);
+        } else {
+            imp.end_stack.set_visible(false);
+        }
+    }
+
+    // --- Fixed control signals ---
+
+    pub fn connect_go_back<F: Fn() + 'static>(&self, f: F) {
+        self.imp().go_back.connect_clicked(move |_| f());
+    }
+
+    pub fn connect_selection_start<F: Fn() + 'static>(&self, f: F) {
         self.imp().start_selection.connect_clicked(move |_| f());
     }
 
-    pub fn connect_select_all<F>(&self, f: F)
-    where
-        F: Fn() + 'static,
-    {
+    pub fn connect_select_all<F: Fn() + 'static>(&self, f: F) {
         self.imp().select_all.connect_clicked(move |_| f());
     }
 
-    pub fn connect_selection_cancel<F>(&self, f: F)
-    where
-        F: Fn() + 'static,
-    {
+    pub fn connect_selection_cancel<F: Fn() + 'static>(&self, f: F) {
         self.imp().cancel.connect_clicked(move |_| f());
     }
 
-    pub fn connect_go_back<F>(&self, f: F)
-    where
-        F: Fn() + 'static,
-    {
-        self.imp().go_back.connect_clicked(move |_| f());
-    }
+    // --- Fixed control state ---
 
     pub fn set_can_go_back(&self, can_go_back: bool) {
         self.imp().go_back.set_visible(can_go_back);
@@ -130,15 +150,15 @@ impl HeaderBarWidget {
     }
 
     pub fn set_selection_active(&self, active: bool) {
+        let imp = self.imp();
         if active {
-            self.imp()
-                .selection_title
+            imp.selection_title
                 .set_title(&labels::n_tracks_selected_label(0));
-            self.imp().selection_title.set_visible(true);
-            self.imp().selection_header.set_visible(true);
+            imp.selection_title.set_visible(true);
+            imp.selection_header.set_visible(true);
         } else {
-            self.imp().selection_title.set_visible(false);
-            self.imp().selection_header.set_visible(false);
+            imp.selection_title.set_visible(false);
+            imp.selection_header.set_visible(false);
         }
     }
 
@@ -146,38 +166,5 @@ impl HeaderBarWidget {
         self.imp()
             .selection_title
             .set_title(&labels::n_tracks_selected_label(count));
-    }
-
-    pub fn add_classes(&self, classes: &[&str]) {
-        for &class in classes {
-            self.imp().main_header.add_css_class(class);
-        }
-    }
-
-    pub fn remove_classes(&self, classes: &[&str]) {
-        for &class in classes {
-            self.imp().main_header.remove_css_class(class);
-        }
-    }
-
-    pub fn set_title_visible(&self, visible: bool) {
-        self.imp().title.set_visible(visible);
-    }
-
-    pub fn set_title_and_subtitle(&self, title: &str, subtitle: &str) {
-        self.imp().title.set_title(title);
-        self.imp().title.set_subtitle(subtitle);
-    }
-
-    pub fn set_title(&self, title: Option<&str>) {
-        self.imp().title.set_visible(title.is_some());
-        if let Some(title) = title {
-            self.imp().title.set_title(title);
-        }
-    }
-
-    /// Pack a widget at the end of the headerbar (before the selection button).
-    pub fn pack_end(&self, widget: &impl IsA<gtk::Widget>) {
-        self.imp().main_header.pack_end(widget.upcast_ref());
     }
 }

--- a/src/app/components/shell/navigation/factory.rs
+++ b/src/app/components/shell/navigation/factory.rs
@@ -12,6 +12,7 @@ pub struct ScreenFactory {
     worker: Worker,
     shared_layout: Rc<Cell<CardLayout>>,
     shared_size: Rc<Cell<CardSize>>,
+    registrar: HeaderRegistrar,
 }
 
 impl ScreenFactory {
@@ -19,6 +20,7 @@ impl ScreenFactory {
         app_model: Rc<AppModel>,
         dispatcher: Box<dyn ActionDispatcher>,
         worker: Worker,
+        registrar: HeaderRegistrar,
     ) -> Self {
         let tracker = StateTracker::new_from_gsettings();
         Self {
@@ -27,28 +29,25 @@ impl ScreenFactory {
             worker,
             shared_layout: Rc::new(Cell::new(tracker.load_card_layout())),
             shared_size: Rc::new(Cell::new(tracker.load_card_size())),
+            registrar,
         }
     }
 
-    /// Wrap a `CardListComponent` in a `StandardScreen`, packing the view button into the headerbar.
-    fn make_card_page<M: CardListPageModel + 'static>(
+    /// Register a `CardListComponent`'s title and view button with the shared
+    /// header (keyed by `name`) and return the page as-is (no local header).
+    fn register_card_page<M: CardListPageModel + 'static>(
+        &self,
+        name: &str,
+        title: &str,
         page: CardListComponent<M>,
-        screen_model: DefaultHeaderBarModel,
-    ) -> StandardScreen<DefaultHeaderBarModel> {
-        let view_btn = page.view_button().clone();
-        let screen = StandardScreen::new(page, Rc::new(screen_model));
-        screen.headerbar().pack_end(&view_btn);
-        screen
+    ) -> CardListComponent<M> {
+        self.registrar.set_static_title(name, title);
+        self.registrar.add_end(name, page.view_button());
+        page
     }
 
     pub fn make_library(&self) -> impl ListenerComponent {
         let model = SavedAlbumsModel::new(Rc::clone(&self.app_model), self.dispatcher.box_clone());
-        let screen_model = DefaultHeaderBarModel::new(
-            Some(gettext("Library")),
-            None,
-            Rc::clone(&self.app_model),
-            self.dispatcher.box_clone(),
-        );
         let page = make_saved_albums(
             self.worker.clone(),
             model,
@@ -56,7 +55,7 @@ impl ScreenFactory {
             Rc::clone(&self.shared_size),
             Rc::clone(&self.dispatcher),
         );
-        Self::make_card_page(page, screen_model)
+        self.register_card_page("library", &gettext("Library"), page)
     }
 
     pub fn make_sidebar(&self, listbox: gtk::ListBox) -> impl ListenerComponent {
@@ -67,12 +66,6 @@ impl ScreenFactory {
     pub fn make_saved_playlists(&self) -> impl ListenerComponent {
         let model =
             SavedPlaylistsModel::new(Rc::clone(&self.app_model), self.dispatcher.box_clone());
-        let screen_model = DefaultHeaderBarModel::new(
-            Some(gettext("Playlists")),
-            None,
-            Rc::clone(&self.app_model),
-            self.dispatcher.box_clone(),
-        );
         let page = make_saved_playlists(
             self.worker.clone(),
             model,
@@ -80,17 +73,11 @@ impl ScreenFactory {
             Rc::clone(&self.shared_size),
             Rc::clone(&self.dispatcher),
         );
-        Self::make_card_page(page, screen_model)
+        self.register_card_page("saved_playlists", &gettext("Playlists"), page)
     }
 
     pub fn make_saved_artists(&self) -> impl ListenerComponent {
         let model = SavedArtistsModel::new(Rc::clone(&self.app_model), self.dispatcher.box_clone());
-        let screen_model = DefaultHeaderBarModel::new(
-            Some(gettext("Artists")),
-            None,
-            Rc::clone(&self.app_model),
-            self.dispatcher.box_clone(),
-        );
         let page = make_saved_artists(
             self.worker.clone(),
             model,
@@ -98,7 +85,7 @@ impl ScreenFactory {
             Rc::clone(&self.shared_size),
             Rc::clone(&self.dispatcher),
         );
-        Self::make_card_page(page, screen_model)
+        self.register_card_page("saved_artists", &gettext("Artists"), page)
     }
 
     pub fn make_now_playing(&self) -> impl ListenerComponent {
@@ -106,7 +93,12 @@ impl ScreenFactory {
             Rc::clone(&self.app_model),
             self.dispatcher.box_clone(),
         ));
-        NowPlaying::new(model, self.worker.clone())
+        NowPlaying::new(
+            model,
+            self.worker.clone(),
+            self.registrar.clone(),
+            "now_playing".to_string(),
+        )
     }
 
     pub fn make_saved_tracks(&self) -> impl ListenerComponent {
@@ -114,16 +106,22 @@ impl ScreenFactory {
             Rc::clone(&self.app_model),
             self.dispatcher.box_clone(),
         ));
-        SavedTracks::new(model, self.worker.clone())
+        SavedTracks::new(
+            model,
+            self.worker.clone(),
+            self.registrar.clone(),
+            "saved_tracks".to_string(),
+        )
     }
 
     pub fn make_album_details(&self, id: String) -> impl ListenerComponent {
+        let name = format!("album_{id}");
         let model = Rc::new(DetailsModel::new(
             id,
             Rc::clone(&self.app_model),
             self.dispatcher.box_clone(),
         ));
-        Details::new(model, self.worker.clone())
+        Details::new(model, self.worker.clone(), self.registrar.clone(), name)
     }
 
     pub fn make_search_results(&self) -> impl ListenerComponent {
@@ -135,10 +133,12 @@ impl ScreenFactory {
             Rc::clone(&self.shared_layout),
             Rc::clone(&self.shared_size),
             Rc::clone(&self.dispatcher),
+            self.registrar.clone(),
         )
     }
 
     pub fn make_artist_details(&self, id: String) -> impl ListenerComponent {
+        let name = format!("artist_{id}");
         let model = Rc::new(ArtistDetailsModel::new(
             id,
             Rc::clone(&self.app_model),
@@ -150,19 +150,23 @@ impl ScreenFactory {
             Rc::clone(&self.shared_layout),
             Rc::clone(&self.shared_size),
             Rc::clone(&self.dispatcher),
+            self.registrar.clone(),
+            name,
         )
     }
 
     pub fn make_playlist_details(&self, id: String) -> impl ListenerComponent {
+        let name = format!("playlist_{id}");
         let model = Rc::new(PlaylistDetailsModel::new(
             id,
             Rc::clone(&self.app_model),
             self.dispatcher.box_clone(),
         ));
-        PlaylistDetails::new(model, self.worker.clone())
+        PlaylistDetails::new(model, self.worker.clone(), self.registrar.clone(), name)
     }
 
     pub fn make_user_details(&self, id: String) -> impl ListenerComponent {
+        let name = format!("user_{id}");
         let model =
             UserDetailsModel::new(id, Rc::clone(&self.app_model), self.dispatcher.box_clone());
         UserDetails::new(
@@ -171,6 +175,8 @@ impl ScreenFactory {
             Rc::clone(&self.shared_layout),
             Rc::clone(&self.shared_size),
             Rc::clone(&self.dispatcher),
+            self.registrar.clone(),
+            name,
         )
     }
 }

--- a/src/app/components/shell/navigation/home.rs
+++ b/src/app/components/shell/navigation/home.rs
@@ -82,15 +82,8 @@ impl Component for HomePane {
 
 impl EventListener for HomePane {
     fn on_event(&mut self, event: &AppEvent) {
-        match event {
-            AppEvent::NowPlayingShown => {
-                self.stack
-                    .set_visible_child_name(SidebarDestination::NowPlaying.id());
-            }
-            AppEvent::BrowserEvent(BrowserEvent::HomeVisiblePageChanged(page)) => {
-                self.stack.set_visible_child_name(page);
-            }
-            _ => {}
+        if let AppEvent::BrowserEvent(BrowserEvent::HomeVisiblePageChanged(page)) = event {
+            self.stack.set_visible_child_name(page);
         }
         self.broadcast_event(event);
     }

--- a/src/app/components/shell/navigation/navigation.rs
+++ b/src/app/components/shell/navigation/navigation.rs
@@ -1,5 +1,9 @@
 use gtk::prelude::WidgetExt;
+use std::cell::Cell;
 use std::rc::Rc;
+
+use gio::prelude::{ActionExt, ActionMapExt};
+use glib::prelude::ToVariant;
 
 use crate::app::components::{EventListener, ListenerComponent};
 use crate::app::state::ScreenName;
@@ -23,36 +27,109 @@ impl Navigation {
         navigation_stack: gtk::Stack,
         home_listbox: gtk::ListBox,
         screen_factory: ScreenFactory,
+        window: libadwaita::ApplicationWindow,
     ) -> Self {
         let model = Rc::new(model);
 
+        // "win.show-sidebar" toggle action. NavigationSplitView has no such
+        // property, so `collapsed` handles mobile while the desktop show/hide
+        // detaches the sidebar page and zeroes its width to fill the content.
+        let sidebar_page = split_view.sidebar();
+        // Captured so hide/show can restore the split view's widths exactly.
+        let min_sidebar_width = split_view.min_sidebar_width();
+        let max_sidebar_width = split_view.max_sidebar_width();
+        // Set when the user hid the sidebar on desktop, to restore on return.
+        let desktop_hidden = Rc::new(Cell::new(false));
+
+        let show_sidebar_action = gio::SimpleAction::new_stateful(
+            "show-sidebar",
+            None,
+            &sidebar_is_visible(&split_view).to_variant(),
+        );
+        show_sidebar_action.connect_change_state(clone!(
+            #[weak]
+            split_view,
+            #[strong]
+            sidebar_page,
+            #[strong]
+            desktop_hidden,
+            move |action, state| {
+                let want_visible = state.and_then(|s| s.get::<bool>()).unwrap_or(true);
+                if split_view.is_collapsed() {
+                    // Mobile: switch between the sidebar pane and the page.
+                    split_view.set_show_content(!want_visible);
+                } else {
+                    // Desktop: hide by detaching the sidebar, show by re-attaching.
+                    desktop_hidden.set(!want_visible);
+                    set_desktop_sidebar(
+                        &split_view,
+                        &sidebar_page,
+                        !want_visible,
+                        min_sidebar_width,
+                        max_sidebar_width,
+                    );
+                }
+                action.set_state(&want_visible.to_variant());
+            }
+        ));
+        window.add_action(&show_sidebar_action);
+
+        // On mobile/desktop switch: toggle styling, keep the sidebar reachable
+        // on mobile or re-apply the desktop preference, and sync state.
         split_view.connect_collapsed_notify(clone!(
             #[weak]
             model,
+            #[weak]
+            show_sidebar_action,
+            #[strong]
+            sidebar_page,
+            #[strong]
+            desktop_hidden,
             move |split_view| {
-                let is_main = split_view.shows_content();
                 let folded = split_view.is_collapsed();
                 if folded {
+                    // Mobile needs the sidebar attached so it can be reached.
+                    set_desktop_sidebar(
+                        split_view,
+                        &sidebar_page,
+                        false,
+                        min_sidebar_width,
+                        max_sidebar_width,
+                    );
                     split_view.add_css_class("collapsed");
+                    split_view.set_show_content(true);
                 } else {
+                    set_desktop_sidebar(
+                        split_view,
+                        &sidebar_page,
+                        desktop_hidden.get(),
+                        min_sidebar_width,
+                        max_sidebar_width,
+                    );
                     split_view.remove_css_class("collapsed");
                 }
+                let is_main = split_view.shows_content();
                 model.set_nav_hidden(folded && is_main);
+                sync_show_sidebar_state(&show_sidebar_action, split_view);
             }
         ));
 
+        // On visible-pane change: keep styling, nav-hidden and toggle in sync.
         split_view.connect_show_content_notify(clone!(
             #[weak]
             model,
+            #[weak]
+            show_sidebar_action,
             move |split_view| {
-                let is_main = split_view.shows_content();
                 let folded = split_view.is_collapsed();
                 if folded {
                     split_view.add_css_class("collapsed");
                 } else {
                     split_view.remove_css_class("collapsed");
                 }
+                let is_main = split_view.shows_content();
                 model.set_nav_hidden(folded && is_main);
+                sync_show_sidebar_state(&show_sidebar_action, split_view);
             }
         ));
 
@@ -156,5 +233,49 @@ impl EventListener for Navigation {
         for child in self.children.iter_mut() {
             child.on_event(event);
         }
+    }
+}
+
+/// Whether the sidebar is on screen: shown pane on mobile, attached page on
+/// desktop.
+fn sidebar_is_visible(split_view: &libadwaita::NavigationSplitView) -> bool {
+    if split_view.is_collapsed() {
+        !split_view.shows_content()
+    } else {
+        split_view.sidebar().is_some()
+    }
+}
+
+/// Show or hide the sidebar on the desktop layout by detaching the page and
+/// zeroing its width (showing restores it). Avoids `collapsed`/`show-content`
+/// so the mobile flow is untouched.
+fn set_desktop_sidebar(
+    split_view: &libadwaita::NavigationSplitView,
+    sidebar_page: &Option<libadwaita::NavigationPage>,
+    hidden: bool,
+    min_width: f64,
+    max_width: f64,
+) {
+    if hidden {
+        split_view.set_sidebar(libadwaita::NavigationPage::NONE);
+        split_view.set_min_sidebar_width(0.0);
+        split_view.set_max_sidebar_width(0.0);
+    } else {
+        if split_view.sidebar().is_none() {
+            split_view.set_sidebar(sidebar_page.as_ref());
+        }
+        split_view.set_min_sidebar_width(min_width);
+        split_view.set_max_sidebar_width(max_width);
+    }
+}
+
+/// Sync the "show-sidebar" action state with actual sidebar visibility.
+fn sync_show_sidebar_state(
+    action: &gio::SimpleAction,
+    split_view: &libadwaita::NavigationSplitView,
+) {
+    let visible = sidebar_is_visible(split_view);
+    if action.state().and_then(|s| s.get::<bool>()) != Some(visible) {
+        action.set_state(&visible.to_variant());
     }
 }

--- a/src/app/components/shell/playback/component.rs
+++ b/src/app/components/shell/playback/component.rs
@@ -1,14 +1,16 @@
 use std::ops::Deref;
 use std::rc::Rc;
 
+use gtk::prelude::*;
+
+use crate::app::components::sidebar::SidebarDestination;
 use crate::app::components::EventListener;
 use crate::app::models::*;
 use crate::app::state::{PlaybackAction, PlaybackEvent, ScreenName, SelectionEvent};
-use crate::app::{
-    ActionDispatcher, AppAction, AppEvent, AppModel, AppState, BrowserAction, Worker,
-};
+use crate::app::{ActionDispatcher, AppEvent, AppModel, AppState, BrowserAction, Worker};
 
 use super::playback_widget::PlaybackWidget;
+use super::PlaybackInfoMobileWidget;
 
 pub struct PlaybackModel {
     app_model: Rc<AppModel>,
@@ -28,9 +30,12 @@ impl PlaybackModel {
     }
 
     fn go_home(&self) {
-        self.dispatcher.dispatch(AppAction::ViewNowPlaying);
-        self.dispatcher
-            .dispatch(BrowserAction::NavigationPopTo(ScreenName::Home).into());
+        // Reach now-playing like the sidebar does: pop to home and select its
+        // now-playing sub-page, reusing the home sub-page switch path.
+        self.dispatcher.dispatch_many(vec![
+            BrowserAction::NavigationPopTo(ScreenName::Home).into(),
+            BrowserAction::SetHomeVisiblePage(SidebarDestination::NowPlaying.id()).into(),
+        ]);
     }
 
     fn is_playing(&self) -> bool {
@@ -81,11 +86,17 @@ impl PlaybackModel {
 pub struct PlaybackControl {
     model: Rc<PlaybackModel>,
     widget: PlaybackWidget,
+    mobile_now_playing: PlaybackInfoMobileWidget,
     worker: Worker,
 }
 
 impl PlaybackControl {
-    pub fn new(model: PlaybackModel, widget: PlaybackWidget, worker: Worker) -> Self {
+    pub fn new(
+        model: PlaybackModel,
+        widget: PlaybackWidget,
+        mobile_now_playing: PlaybackInfoMobileWidget,
+        worker: Worker,
+    ) -> Self {
         let model = Rc::new(model);
 
         widget.connect_play_pause(clone!(
@@ -132,6 +143,7 @@ impl PlaybackControl {
         Self {
             model,
             widget,
+            mobile_now_playing,
             worker,
         }
     }
@@ -153,6 +165,9 @@ impl PlaybackControl {
         if let Some(song) = self.model.current_song() {
             self.widget
                 .set_title_and_artist(&song.title, &song.artists_name());
+            self.mobile_now_playing
+                .set_title_and_artist(&song.title, &song.artists_name());
+            self.mobile_now_playing.set_visible(true);
             self.widget.set_song_duration(Some(song.duration_ms as f64));
             if let Some(url) = song.art.as_ref().and_then(|s| s.best_for_width(120)) {
                 self.widget
@@ -160,6 +175,8 @@ impl PlaybackControl {
             }
         } else {
             self.widget.reset_info();
+            self.mobile_now_playing.reset_info();
+            self.mobile_now_playing.set_visible(false);
         }
     }
 

--- a/src/app/components/shell/playback/mod.rs
+++ b/src/app/components/shell/playback/mod.rs
@@ -4,9 +4,11 @@ mod playback_info;
 mod playback_info_mobile;
 mod playback_widget;
 pub use component::*;
+pub use playback_info_mobile::PlaybackInfoMobileWidget;
 
 use glib::prelude::*;
 
 pub fn expose_widgets() {
     playback_widget::PlaybackWidget::static_type();
+    playback_info_mobile::PlaybackInfoMobileWidget::static_type();
 }

--- a/src/app/components/shell/playback/playback_info.blp
+++ b/src/app/components/shell/playback/playback_info.blp
@@ -19,6 +19,7 @@ template $PlaybackInfoWidget : Button {
     Picture playing_image {
       width-request: 56;
       height-request: 56;
+      can-shrink: true;
       content-fit: cover;
       overflow: hidden;
 

--- a/src/app/components/shell/playback/playback_widget.blp
+++ b/src/app/components/shell/playback/playback_widget.blp
@@ -51,152 +51,140 @@ template $PlaybackWidget : Box {
 
   Adw.BreakpointBin {
     width-request: 1;
-    height-request: 1;
+    height-request: 84;
     margin-top: 4;
 
     Adw.Breakpoint {
       condition("max-width:764sp")
 
       setters {
-        layout-stack.visible-child-name: "mobile";
+        now_playing_box.visible: false;
+        now_playing_button_box.visible: true;
+        volume_slider_box.visible: false;
+        volume_button.visible: true;
+        playback-center.margin-start: 16;
+        playback-center.margin-end: 16;
       }
     }
 
-    child: Stack layout-stack {
-      vhomogeneous: false;
-      hhomogeneous: false;
+    child: CenterBox playback-center {
+      halign: fill;
+      hexpand: true;
+      shrink-center-last: true;
+      height-request: 68;
+      margin-top: 8;
+      margin-bottom: 8;
+      margin-start: 8;
+      margin-end: 8;
 
-      StackPage {
-        name: "desktop";
-        child: Grid desktop-grid {
-          halign: fill;
-          hexpand: true;
-          column-homogeneous: true;
-          margin-top: 8;
-          margin-bottom: 8;
-          margin-start: 8;
-          margin-end: 8;
+      [start]
+      Box now_playing_start {
+        hexpand: true;
+        halign: start;
+        valign: center;
 
-          Box {
-            hexpand: true;
-            height-request: 68;
+        // Narrow mode replaces the track info with a compact button. The
+        // breakpoint toggles this box; the button inside is shown in code only
+        // when a track is playing.
+        Box now_playing_button_box {
+          visible: false;
+          valign: center;
 
-            layout {
-              column-span: "1";
-              column: "0";
-              row: "0";
-            }
-
-            $PlaybackInfoWidget now_playing {
-              receives-default: "1";
-              halign: "start";
-              valign: "center";
-              has-frame: "0";
-              visible: false;
-            }
-          }
-
-          $PlaybackControlsWidget controls {
-            halign: center;
-            layout {
-              column-span: "1";
-              column: "1";
-              row: "0";
-            }
-          }
-
-          Stack volume-stack {
-            hexpand: true;
-            halign: end;
-
-            layout {
-              column-span: "1";
-              column: "2";
-              row: "0";
-            }
-
-            StackPage {
-              name: 'slider';
-              child: Box {
-                width-request: 250;
-                Image {
-                  icon-name: 'multimedia-volume-control-symbolic';
-                }
-
-                Scale volume_slider {
-                  hexpand: true;
-                  show-fill-level: true;
-                  restrict-to-fill-level: false;
-                  value-pos: left;
-
-                  styles [
-                    'volume-slider'
-                  ]
-
-                  adjustment: Adjustment {
-                    lower: 0.0;
-                    value: 0.7;
-                    upper: 1.0;
-                    step-increment: 0.01;
-                    page-increment: 0.05;
-                  };
-                }
-              };
-            }
-          }
-        };
-      }
-
-      StackPage {
-        name: "mobile";
-        child: Box {
-          orientation: vertical;
-          halign: fill;
-          hexpand: true;
-
-          $PlaybackInfoMobileWidget mobile_now_playing {
+          Button now_playing_button {
             visible: false;
-            hexpand: true;
+            icon-name: "music-queue-symbolic";
+            tooltip-text: _("Now playing");
+            focus-on-click: false;
+            can-focus: false;
+            valign: center;
 
             styles [
-              "mobile-now-playing",
+              "flat",
             ]
           }
+        }
 
-          Box {
-            hexpand: true;
-            margin-top: 8;
-            margin-bottom: 8;
-            margin-start: 8;
-            margin-end: 8;
+        Box now_playing_box {
+          hexpand: true;
+          height-request: 68;
+          overflow: hidden;
+          halign: start;
 
-            $PlaybackControlsWidget mobile_controls {
-              halign: center;
-              valign: center;
-              hexpand: true;
-            }
-
-            MenuButton {
-              icon-name: 'multimedia-volume-control-symbolic';
-              halign: end;
-              valign: center;
-              direction: up;
-              focus-on-click: false;
-              can-focus: false;
-              styles [
-                "flat"
-              ]
-              popover: Popover {
-                child: Scale {
-                  inverted: true;
-                  orientation: vertical;
-                  height-request: 160;
-                  adjustment: bind volume_slider.adjustment;
-                };
-              };
-            }
+          $PlaybackInfoWidget now_playing {
+            receives-default: "1";
+            halign: "start";
+            valign: "center";
+            has-frame: "0";
+            visible: false;
           }
-        };
+        }
+      }
+
+      [center]
+      $PlaybackControlsWidget controls {
+        // Keep the control cluster at natural width. Its template sets
+        // hexpand:true, but with CenterBox shrink-center-last an expanding
+        // centre squeezes the start/end slots and pushes the volume off-edge.
+        hexpand: false;
+        halign: center;
+        valign: center;
+      }
+
+      [end]
+      Box {
+        hexpand: true;
+        halign: end;
+        valign: center;
+
+        Box volume_slider_box {
+          width-request: 250;
+
+          Image {
+            icon-name: 'multimedia-volume-control-symbolic';
+          }
+
+          Scale volume_slider {
+            hexpand: true;
+            show-fill-level: true;
+            restrict-to-fill-level: false;
+            value-pos: left;
+
+            styles [
+              'volume-slider'
+            ]
+
+            adjustment: Adjustment {
+              lower: 0.0;
+              value: 0.7;
+              upper: 1.0;
+              step-increment: 0.01;
+              page-increment: 0.05;
+            };
+          }
+        }
+
+        MenuButton volume_button {
+          visible: false;
+          icon-name: 'multimedia-volume-control-symbolic';
+          halign: end;
+          valign: center;
+          direction: up;
+          focus-on-click: false;
+          can-focus: false;
+
+          styles [
+            "flat"
+          ]
+
+          popover: Popover {
+            child: Scale {
+              inverted: true;
+              orientation: vertical;
+              height-request: 160;
+              adjustment: bind volume_slider.adjustment;
+            };
+          };
+        }
       }
     };
   }

--- a/src/app/components/shell/playback/playback_widget.rs
+++ b/src/app/components/shell/playback/playback_widget.rs
@@ -10,7 +10,6 @@ use crate::app::Worker;
 
 use super::playback_controls::PlaybackControlsWidget;
 use super::playback_info::PlaybackInfoWidget;
-use super::playback_info_mobile::PlaybackInfoMobileWidget;
 
 mod imp {
 
@@ -23,13 +22,10 @@ mod imp {
         pub controls: TemplateChild<PlaybackControlsWidget>,
 
         #[template_child]
-        pub mobile_controls: TemplateChild<PlaybackControlsWidget>,
-
-        #[template_child]
         pub now_playing: TemplateChild<PlaybackInfoWidget>,
 
         #[template_child]
-        pub mobile_now_playing: TemplateChild<PlaybackInfoMobileWidget>,
+        pub now_playing_button: TemplateChild<gtk::Button>,
 
         #[template_child]
         pub seek_bar: TemplateChild<gtk::Scale>,
@@ -110,18 +106,14 @@ impl PlaybackWidget {
         let widget = self.imp();
         widget.now_playing.set_visible(true);
         widget.now_playing.set_title_and_artist(title, artist);
-        widget.mobile_now_playing.set_visible(true);
-        widget
-            .mobile_now_playing
-            .set_title_and_artist(title, artist);
+        widget.now_playing_button.set_visible(true);
     }
 
     pub fn reset_info(&self) {
         let widget = self.imp();
         widget.now_playing.set_visible(false);
         widget.now_playing.reset_info();
-        widget.mobile_now_playing.set_visible(false);
-        widget.mobile_now_playing.reset_info();
+        widget.now_playing_button.set_visible(false);
         self.set_song_duration(None);
     }
 
@@ -194,8 +186,12 @@ impl PlaybackWidget {
         F: Fn() + Clone + 'static,
     {
         let widget = self.imp();
-        let f_clone = f.clone();
-        widget.now_playing.connect_clicked(move |_| f_clone());
+        let f_info = f.clone();
+        widget.now_playing.connect_clicked(move |_| f_info());
+        let f_button = f.clone();
+        widget
+            .now_playing_button
+            .connect_clicked(move |_| f_button());
     }
 
     pub fn connect_seek<Seek>(&self, seek: Seek)
@@ -223,7 +219,6 @@ impl PlaybackWidget {
     pub fn set_playing(&self, is_playing: bool) {
         let widget = self.imp();
         widget.controls.set_playing(is_playing);
-        widget.mobile_controls.set_playing(is_playing);
         if is_playing {
             self.resume_seek_position();
         } else {
@@ -234,13 +229,11 @@ impl PlaybackWidget {
     pub fn set_repeat_mode(&self, mode: RepeatMode) {
         let widget = self.imp();
         widget.controls.set_repeat_mode(mode);
-        widget.mobile_controls.set_repeat_mode(mode);
     }
 
     pub fn set_shuffled(&self, shuffled: bool) {
         let widget = self.imp();
         widget.controls.set_shuffled(shuffled);
-        widget.mobile_controls.set_shuffled(shuffled);
     }
 
     pub fn set_seekbar_visible(&self, visible: bool) {
@@ -258,8 +251,7 @@ impl PlaybackWidget {
         F: Fn() + Clone + 'static,
     {
         let widget = self.imp();
-        widget.controls.connect_play_pause(f.clone());
-        widget.mobile_controls.connect_play_pause(f);
+        widget.controls.connect_play_pause(f);
     }
 
     pub fn connect_prev<F>(&self, f: F)
@@ -267,8 +259,7 @@ impl PlaybackWidget {
         F: Fn() + Clone + 'static,
     {
         let widget = self.imp();
-        widget.controls.connect_prev(f.clone());
-        widget.mobile_controls.connect_prev(f);
+        widget.controls.connect_prev(f);
     }
 
     pub fn connect_next<F>(&self, f: F)
@@ -276,8 +267,7 @@ impl PlaybackWidget {
         F: Fn() + Clone + 'static,
     {
         let widget = self.imp();
-        widget.controls.connect_next(f.clone());
-        widget.mobile_controls.connect_next(f);
+        widget.controls.connect_next(f);
     }
 
     pub fn connect_shuffle<F>(&self, f: F)
@@ -285,8 +275,7 @@ impl PlaybackWidget {
         F: Fn() + Clone + 'static,
     {
         let widget = self.imp();
-        widget.controls.connect_shuffle(f.clone());
-        widget.mobile_controls.connect_shuffle(f);
+        widget.controls.connect_shuffle(f);
     }
 
     pub fn connect_repeat<F>(&self, f: F)
@@ -294,8 +283,7 @@ impl PlaybackWidget {
         F: Fn() + Clone + 'static,
     {
         let widget = self.imp();
-        widget.controls.connect_repeat(f.clone());
-        widget.mobile_controls.connect_repeat(f);
+        widget.controls.connect_repeat(f);
     }
 
     pub fn connect_volume_changed<F>(&self, f: F)

--- a/src/app/components/shell/window/mod.rs
+++ b/src/app/components/shell/window/mod.rs
@@ -1,3 +1,6 @@
+mod shell_box;
+pub use shell_box::expose_widgets;
+
 use gettextrs::gettext;
 use gio::prelude::SettingsExt;
 use gtk::prelude::*;

--- a/src/app/components/shell/window/shell_box.rs
+++ b/src/app/components/shell/window/shell_box.rs
@@ -1,0 +1,131 @@
+//! Custom root layout for the main window.
+//!
+//! Stacks content (first child) above fixed-height bottom bars (the mobile
+//! now-playing bar and the playback bar). Content absorbs vertical shrink; the
+//! bars keep their natural height, pinned to the bottom.
+//!
+//! A plain `GtkBox` can't do this: forced shorter than its total minimum it
+//! clips the last child (the playback controls), the reported bug. `ShellBox`
+//! subclasses `GtkWidget` so its `measure`/`size_allocate` are used (a `GtkBox`
+//! routes them through `GtkBoxLayout`), and reports only the bars as the
+//! vertical minimum so content can shrink to zero without squeezing them.
+
+use gtk::glib;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug, Default)]
+    pub struct ShellBox;
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for ShellBox {
+        const NAME: &'static str = "ShellBox";
+        type Type = super::ShellBox;
+        type ParentType = gtk::Widget;
+    }
+
+    impl ShellBox {
+        /// Visible children in document order (content first, then bottom bars).
+        fn layout_children(&self) -> Vec<gtk::Widget> {
+            let mut children = Vec::new();
+            let mut child = self.obj().first_child();
+            while let Some(widget) = child {
+                let next = widget.next_sibling();
+                if widget.should_layout() {
+                    children.push(widget);
+                }
+                child = next;
+            }
+            children
+        }
+    }
+
+    impl ObjectImpl for ShellBox {
+        fn constructed(&self) {
+            self.parent_constructed();
+            // Clip over-small content; the bars stay pinned within bounds.
+            self.obj().set_overflow(gtk::Overflow::Hidden);
+        }
+
+        fn dispose(&self) {
+            // A plain GtkWidget does not unparent its children automatically.
+            while let Some(child) = self.obj().first_child() {
+                child.unparent();
+            }
+        }
+    }
+
+    impl WidgetImpl for ShellBox {
+        fn request_mode(&self) -> gtk::SizeRequestMode {
+            gtk::SizeRequestMode::HeightForWidth
+        }
+
+        fn measure(&self, orientation: gtk::Orientation, for_size: i32) -> (i32, i32, i32, i32) {
+            let children = self.layout_children();
+            let Some((content, bars)) = children.split_first() else {
+                return (0, 0, -1, -1);
+            };
+
+            if orientation == gtk::Orientation::Horizontal {
+                let mut min = 0;
+                let mut nat = 0;
+                for child in &children {
+                    let (child_min, child_nat, _, _) = child.measure(orientation, -1);
+                    min = min.max(child_min);
+                    nat = nat.max(child_nat);
+                }
+                return (min, nat, -1, -1);
+            }
+
+            // Vertical: bars form the whole minimum at natural height; content
+            // adds to natural only, so it can be squeezed to zero.
+            let mut bars_height = 0;
+            for bar in bars {
+                let (_, bar_nat, _, _) = bar.measure(orientation, for_size);
+                bars_height += bar_nat;
+            }
+            let (_, content_nat, _, _) = content.measure(orientation, for_size);
+            (bars_height, content_nat + bars_height, -1, -1)
+        }
+
+        fn size_allocate(&self, width: i32, height: i32, _baseline: i32) {
+            let children = self.layout_children();
+            let Some((content, bars)) = children.split_first() else {
+                return;
+            };
+
+            let mut bar_heights = Vec::with_capacity(bars.len());
+            let mut bars_height = 0;
+            for bar in bars {
+                let (_, bar_nat, _, _) = bar.measure(gtk::Orientation::Vertical, width);
+                bar_heights.push(bar_nat);
+                bars_height += bar_nat;
+            }
+
+            // Content fills the space above the bars (clamped at zero).
+            let content_height = (height - bars_height).max(0);
+            content.allocate(width, content_height, -1, None);
+
+            // Pin bars to the bottom, stacking upward so the last sits flush.
+            let mut y = height;
+            for (bar, bar_height) in bars.iter().zip(bar_heights.iter()).rev() {
+                y -= bar_height;
+                let transform =
+                    gtk::gsk::Transform::new().translate(&gtk::graphene::Point::new(0.0, y as f32));
+                bar.allocate(width, *bar_height, -1, Some(transform));
+            }
+        }
+    }
+}
+
+glib::wrapper! {
+    pub struct ShellBox(ObjectSubclass<imp::ShellBox>) @extends gtk::Widget;
+}
+
+/// Ensure the GObject type is registered so the builder can instantiate it.
+pub fn expose_widgets() {
+    ShellBox::static_type();
+}

--- a/src/app/components/widgets/details_page/component.rs
+++ b/src/app/components/widgets/details_page/component.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use super::{is_playback_event, DetailsPage, PageModel};
 use crate::app::components::{
     CardLayout, CardList, CardListModel, CardSize, Component, EmbeddedCardList, EventListener,
-    FilterToggle, HeaderBarModel, Playlist, PlaylistModel, SortOrder,
+    FilterToggle, HeaderBarModel, HeaderRegistrar, Playlist, PlaylistModel, SortOrder,
 };
 use crate::app::dispatch::Worker;
 use crate::app::{ActionDispatcher, AppEvent};
@@ -18,6 +18,10 @@ pub struct DetailsPageComponent<M> {
     page: DetailsPage,
     content: gtk::Box,
     children: Vec<Box<dyn EventListener>>,
+    registrar: HeaderRegistrar,
+    name: String,
+    header_title: libadwaita::WindowTitle,
+    end_box: gtk::Box,
 }
 
 impl<M: PageModel + 'static> DetailsPageComponent<M> {
@@ -29,19 +33,38 @@ impl<M: PageModel + 'static> DetailsPageComponent<M> {
         model: Rc<M>,
         headerbar_model: Rc<H>,
         worker: Worker,
+        registrar: HeaderRegistrar,
+        name: String,
     ) -> Self {
         let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
         let page = DetailsPage::new(model.header_image_shape(), &content);
-        let headerbar = page.create_headerbar_listener(headerbar_model);
+
+        // Register this screen's header contribution: a scroll-revealed title,
+        // an end-button container, and the selection/back model.
+        let header_title = registrar.add_title_widget(&name);
+        page.connect_title_reveal(&header_title);
+        let end_box = gtk::Box::new(gtk::Orientation::Horizontal, 6);
+        registrar.add_end(&name, &end_box);
+        registrar.register_model(&name, headerbar_model);
+
         let mut c = Self {
             model,
             worker,
             page,
             content,
-            children: vec![headerbar],
+            children: vec![],
+            registrar,
+            name,
+            header_title,
+            end_box,
         };
         c.wire();
         c
+    }
+
+    /// Append a widget to this page's end area in the shared header.
+    pub fn add_header_end(&self, widget: &impl IsA<gtk::Widget>) {
+        self.end_box.append(widget);
     }
 
     /// Create a [`Playlist`] child, appending an optional label and a `ListView`
@@ -166,9 +189,7 @@ impl<M: PageModel + 'static> DetailsPageComponent<M> {
             shared_size,
             dispatcher,
         );
-        if let Some(hb) = self.page.headerbar() {
-            hb.pack_end(embedded.view_button());
-        }
+        self.add_header_end(embedded.view_button());
         self.children.push(Box::new(embedded));
     }
 
@@ -246,6 +267,8 @@ impl<M: PageModel + 'static> DetailsPageComponent<M> {
         if let Some(title) = self.model.get_title() {
             let subtitle = self.model.get_subtitle().unwrap_or_default();
             self.page.set_details(&title, &subtitle);
+            self.header_title.set_title(&title);
+            self.header_title.set_subtitle(&subtitle);
         }
 
         // Set subtitle links if the model provides them
@@ -329,6 +352,13 @@ impl<M: PageModel + 'static> Component for DetailsPageComponent<M> {
     }
     fn get_children(&mut self) -> Option<&mut Vec<Box<dyn EventListener>>> {
         Some(&mut self.children)
+    }
+}
+
+impl<M> Drop for DetailsPageComponent<M> {
+    fn drop(&mut self) {
+        // Unregister from the shared header so a re-push re-registers cleanly.
+        self.registrar.remove(&self.name);
     }
 }
 

--- a/src/app/components/widgets/details_page/header.blp
+++ b/src/app/components/widgets/details_page/header.blp
@@ -1,32 +1,40 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $DetailsHeaderWidget : Box {
-  orientation: horizontal;
+template $DetailsHeaderWidget : Widget {
   valign: start;
-  vexpand: false;
 
   styles [
     "details-header",
   ]
 
-  Adw.BreakpointBin {
+  Adw.BreakpointBin breakpoint_bin {
     width-request: 1;
     height-request: 1;
     hexpand: true;
 
+    // Narrow: stack artwork above the text/buttons instead of beside them.
     Adw.Breakpoint {
-      condition("max-width: 550sp")
+      condition("max-width: 510sp")
 
+      setters {
+        header_box.orientation: vertical;
+        image_box.halign: center;
+        image_box.valign: start;
+        image_box.margin-end: 0;
+        image_box.margin-bottom: 8;
+      }
     }
 
-    child: Box {
+    child: Box header_box {
       orientation: horizontal;
 
       Box image_box {
         overflow: hidden;
         valign: center;
         margin-end: 12;
+        width-request: 200;
+        height-request: 200;
 
         styles [
           "details-header__image-box",
@@ -59,21 +67,27 @@ template $DetailsHeaderWidget : Box {
         }
       }
 
-      CenterBox {
+      Box content_box {
         orientation: vertical;
         hexpand: true;
+        // Don't propagate the spacers' vexpand: stay at natural height in the
+        // narrow (vertical) layout instead of the desktop artwork height.
+        vexpand: false;
 
-        [start]
-        Box {}
+        // Spacers only expand on desktop (box stretched to artwork height),
+        // centering text and pushing buttons down. In the narrow layout they
+        // collapse to zero so everything stacks tightly.
+        Box {
+          vexpand: true;
+        }
 
-        [center]
         Box info_box {
           orientation: vertical;
           hexpand: true;
 
           Label caption_label {
             halign: start;
-            opacity: 0;
+            visible: false;
 
             styles [
               "caption",
@@ -93,7 +107,7 @@ template $DetailsHeaderWidget : Box {
 
           Label subtitle_label {
             halign: start;
-            opacity: 0;
+            visible: false;
             ellipsize: end;
 
             styles [
@@ -104,6 +118,7 @@ template $DetailsHeaderWidget : Box {
           Box subtitle_links_box {
             orientation: horizontal;
             halign: start;
+            margin-start: -4;
             visible: false;
 
             styles [
@@ -112,11 +127,15 @@ template $DetailsHeaderWidget : Box {
           }
         }
 
-        [end]
+        Box {
+          vexpand: true;
+        }
+
         Box button_box {
           orientation: horizontal;
           spacing: 8;
           hexpand: true;
+          margin-top: 12;
 
           Button play_button {
             icon-name: "media-playback-start-symbolic";

--- a/src/app/components/widgets/details_page/header.rs
+++ b/src/app/components/widgets/details_page/header.rs
@@ -21,10 +21,16 @@ pub enum HeaderImageShape {
 mod imp {
     use super::*;
 
-    /// Inner GObject struct for the composite template defined in `header.blp`.
+    /// Inner GObject struct for the composite template in `header.blp`.
+    ///
+    /// One widget tree serves both layouts; a breakpoint flips `header_box`
+    /// between horizontal (artwork beside text) and vertical (above it).
     #[derive(Debug, Default, CompositeTemplate)]
     #[template(resource = "/dev/diegovsky/Riff/components/details_header.ui")]
     pub struct DetailsHeaderWidget {
+        #[template_child]
+        pub breakpoint_bin: TemplateChild<libadwaita::BreakpointBin>,
+
         #[template_child]
         pub image_box: TemplateChild<gtk::Box>,
 
@@ -66,7 +72,7 @@ mod imp {
     impl ObjectSubclass for DetailsHeaderWidget {
         const NAME: &'static str = "DetailsHeaderWidget";
         type Type = super::DetailsHeaderWidget;
-        type ParentType = gtk::Box;
+        type ParentType = gtk::Widget;
 
         fn class_init(klass: &mut Self::Class) {
             klass.bind_template();
@@ -82,13 +88,41 @@ mod imp {
             self.parent_constructed();
             self.obj().set_overflow(gtk::Overflow::Hidden);
         }
+
+        fn dispose(&self) {
+            // Unparent template children before finalization to avoid a GTK
+            // warning (they parent directly to this widget).
+            while let Some(child) = self.obj().first_child() {
+                child.unparent();
+            }
+        }
     }
-    impl WidgetImpl for DetailsHeaderWidget {}
-    impl BoxImpl for DetailsHeaderWidget {}
+
+    impl WidgetImpl for DetailsHeaderWidget {
+        /// Report natural height as the minimum too. The child `AdwBreakpointBin`
+        /// is pinned to a 1px minimum so the breakpoint can shrink; without this
+        /// the scrolled box could squeeze the header down to that 1px.
+        fn measure(&self, orientation: gtk::Orientation, for_size: i32) -> (i32, i32, i32, i32) {
+            let bin = self.breakpoint_bin.get();
+            let (min, nat, min_baseline, nat_baseline) = bin.measure(orientation, for_size);
+
+            if orientation == gtk::Orientation::Vertical {
+                return (nat, nat, min_baseline, nat_baseline);
+            }
+
+            (min, nat, min_baseline, nat_baseline)
+        }
+
+        fn size_allocate(&self, width: i32, height: i32, baseline: i32) {
+            // Fill this widget with its child; the BreakpointBin evaluates the
+            // breakpoint for `width` and lays out its content.
+            self.breakpoint_bin.allocate(width, height, baseline, None);
+        }
+    }
 }
 
 glib::wrapper! {
-    pub struct DetailsHeaderWidget(ObjectSubclass<imp::DetailsHeaderWidget>) @extends gtk::Widget, gtk::Box;
+    pub struct DetailsHeaderWidget(ObjectSubclass<imp::DetailsHeaderWidget>) @extends gtk::Widget;
 }
 
 /// High-level wrapper around `DetailsHeaderWidget`.
@@ -103,37 +137,29 @@ impl DetailsHeader {
     pub fn new(shape: HeaderImageShape) -> Self {
         let widget: DetailsHeaderWidget = glib::Object::new();
 
-        widget.imp().image.set_halign(gtk::Align::Center);
-        widget.imp().image.set_valign(gtk::Align::Center);
-        widget
-            .imp()
-            .image_box
+        let imp = widget.imp();
+        imp.image.set_halign(gtk::Align::Center);
+        imp.image.set_valign(gtk::Align::Center);
+        imp.image_box
             .add_css_class("details-header__image-placeholder");
+        imp.image_box.add_css_class("card");
 
-        // Apply shape-specific styling.
-        widget.imp().image_box.add_css_class("card");
-        match shape {
-            HeaderImageShape::Square => {}
-            HeaderImageShape::Circle => {
-                widget
-                    .imp()
-                    .image
-                    .add_css_class("details-header__image--circular");
-                widget
-                    .imp()
-                    .image_box
-                    .add_css_class("details-header__image--circular");
-            }
+        if shape == HeaderImageShape::Circle {
+            imp.image.add_css_class("details-header__image--circular");
+            imp.image_box
+                .add_css_class("details-header__image--circular");
         }
 
         Self { widget }
     }
 
-    pub fn widget(&self) -> &gtk::Box {
+    pub fn widget(&self) -> &gtk::Widget {
         self.widget.upcast_ref()
     }
 
     // Text content
+    //
+    // Caption/subtitle use `visible` (not opacity) so empty values take no space.
 
     pub fn set_title(&self, title: &str) {
         self.widget.imp().title_label.set_label(title);
@@ -142,25 +168,19 @@ impl DetailsHeader {
     pub fn set_caption(&self, caption: &str) {
         let imp = self.widget.imp();
         imp.caption_label.set_label(caption);
-        imp.caption_label
-            .set_opacity(if caption.is_empty() { 0.0 } else { 1.0 });
+        imp.caption_label.set_visible(!caption.is_empty());
     }
 
     pub fn set_caption_visible(&self, visible: bool) {
-        self.widget
-            .imp()
-            .caption_label
-            .set_opacity(if visible { 1.0 } else { 0.0 });
+        self.widget.imp().caption_label.set_visible(visible);
     }
 
     pub fn set_subtitle(&self, subtitle: &str) {
         let imp = self.widget.imp();
         imp.subtitle_label.set_label(subtitle);
-        imp.subtitle_label
-            .set_opacity(if subtitle.is_empty() { 0.0 } else { 1.0 });
-        // When setting a plain subtitle, hide the links box
+        imp.subtitle_label.set_visible(!subtitle.is_empty());
+        // A plain subtitle and the links box are mutually exclusive.
         imp.subtitle_links_box.set_visible(false);
-        imp.subtitle_label.set_visible(true);
     }
 
     pub fn get_title_text(&self) -> String {
@@ -181,11 +201,9 @@ impl DetailsHeader {
             gtk::TextDirection::None,
             gtk::IconLookupFlags::empty(),
         );
-        self.widget.imp().image.set_paintable(Some(&icon));
-        self.widget
-            .imp()
-            .image
-            .set_content_fit(gtk::ContentFit::Fill);
+        let imp = self.widget.imp();
+        imp.image.set_paintable(Some(&icon));
+        imp.image.set_content_fit(gtk::ContentFit::Fill);
     }
 
     // Action button state
@@ -202,20 +220,19 @@ impl DetailsHeader {
         } else {
             gettext("Play")
         };
-        self.widget.imp().play_button.set_icon_name(icon);
-        self.widget
-            .imp()
-            .play_button
-            .set_tooltip_text(Some(&tooltip));
+        let play_button = &self.widget.imp().play_button;
+        play_button.set_icon_name(icon);
+        play_button.set_tooltip_text(Some(&tooltip));
     }
 
     /// Update the like button icon to reflect saved/unsaved state.
     pub fn set_liked(&self, is_liked: bool) {
-        self.widget.imp().like_button.set_icon_name(if is_liked {
+        let icon = if is_liked {
             "starred-symbolic"
         } else {
             "non-starred-symbolic"
-        });
+        };
+        self.widget.imp().like_button.set_icon_name(icon);
     }
 
     /// Show or hide the like button.
@@ -227,42 +244,45 @@ impl DetailsHeader {
 
     /// Connect a handler to the play button. Also makes the button visible.
     pub fn connect_play<F: Fn() + 'static>(&self, f: F) {
-        self.widget.imp().play_button.set_visible(true);
-        self.widget.imp().play_button.connect_clicked(move |_| f());
+        let button = &self.widget.imp().play_button;
+        button.set_visible(true);
+        button.connect_clicked(move |_| f());
     }
 
     /// Connect a handler to the shuffle button. Also makes the button visible.
     pub fn connect_shuffle<F: Fn() + 'static>(&self, f: F) {
-        self.widget.imp().shuffle_button.set_visible(true);
-        self.widget
-            .imp()
-            .shuffle_button
-            .connect_clicked(move |_| f());
+        let button = &self.widget.imp().shuffle_button;
+        button.set_visible(true);
+        button.connect_clicked(move |_| f());
     }
 
     /// Connect a handler to the like/save button. Also makes the button visible.
     pub fn connect_liked<F: Fn() + 'static>(&self, f: F) {
-        self.widget.imp().like_button.set_visible(true);
-        self.widget.imp().like_button.connect_clicked(move |_| f());
+        let button = &self.widget.imp().like_button;
+        button.set_visible(true);
+        button.connect_clicked(move |_| f());
     }
 
     /// Connect a handler to the info button. Also makes the button visible.
     pub fn connect_info<F: Fn() + 'static>(&self, f: F) {
-        self.widget.imp().info_button.set_visible(true);
-        self.widget.imp().info_button.connect_clicked(move |_| f());
+        let button = &self.widget.imp().info_button;
+        button.set_visible(true);
+        button.connect_clicked(move |_| f());
     }
 
     /// Connect a handler to the share button. Also makes the button visible.
     pub fn connect_share<F: Fn() + 'static>(&self, f: F) {
-        self.widget.imp().share_button.set_visible(true);
-        self.widget.imp().share_button.connect_clicked(move |_| f());
+        let button = &self.widget.imp().share_button;
+        button.set_visible(true);
+        button.connect_clicked(move |_| f());
     }
 
     /// Connect a handler to the edit button. Also makes the button visible.
     #[allow(dead_code)]
     pub fn connect_edit<F: Fn() + 'static>(&self, f: F) {
-        self.widget.imp().edit_button.set_visible(true);
-        self.widget.imp().edit_button.connect_clicked(move |_| f());
+        let button = &self.widget.imp().edit_button;
+        button.set_visible(true);
+        button.connect_clicked(move |_| f());
     }
 
     /// Set multiple artist link buttons in the subtitle area.
@@ -277,24 +297,21 @@ impl DetailsHeader {
         let imp = self.widget.imp();
         let links_box = &*imp.subtitle_links_box;
 
-        // Clear any previous children
+        // Clear any previous children.
         while let Some(child) = links_box.first_child() {
             links_box.remove(&child);
         }
 
         if artists.is_empty() {
             links_box.set_visible(false);
-            imp.subtitle_label.set_visible(true);
             return;
         }
 
-        // Hide the plain label, show the links box
-        imp.subtitle_label.set_visible(false);
-        imp.subtitle_label.set_opacity(0.0);
+        // Show the links box in place of the plain subtitle label.
         links_box.set_visible(true);
+        imp.subtitle_label.set_visible(false);
 
         let on_clicked = Rc::new(on_clicked);
-
         for (i, (id, name)) in artists.iter().enumerate() {
             if i > 0 {
                 let separator = gtk::Label::new(Some(", "));
@@ -319,7 +336,7 @@ impl DetailsHeader {
 
     // Weak references
 
-    /// Get a weak reference to the underlying widget, suitable for moving into async tasks.
+    /// Weak reference to the underlying widget, for moving into async tasks.
     pub fn widget_weak(&self) -> gtk::glib::WeakRef<DetailsHeaderWidget> {
         self.widget.downgrade()
     }

--- a/src/app/components/widgets/details_page/traits.rs
+++ b/src/app/components/widgets/details_page/traits.rs
@@ -19,7 +19,6 @@ pub trait HasHeaderBarModel:
     fn to_headerbar_model(self: &Rc<Self>) -> Rc<impl HeaderBarModel + 'static> {
         Rc::new(SimpleHeaderBarModelWrapper::new(
             self.clone(),
-            self.app_model.clone(),
             self.dispatcher.box_clone(),
         ))
     }

--- a/src/app/components/widgets/details_page/widget.rs
+++ b/src/app/components/widgets/details_page/widget.rs
@@ -5,10 +5,7 @@ use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use libadwaita::prelude::*;
 
-use crate::app::components::{
-    display_add_css_provider, EventListener, HeaderBarComponent, HeaderBarModel, HeaderBarWidget,
-    CLAMP_MAX_SIZE,
-};
+use crate::app::components::{display_add_css_provider, CLAMP_MAX_SIZE};
 use crate::app::dispatch::Worker;
 use crate::app::loader::ImageLoader;
 use crate::app::models::ImageSet;
@@ -19,10 +16,11 @@ use super::{DetailsHeader, HeaderImageShape, HEADER_IMAGE_SIZE};
 
 /// A reusable details page layout used by album, artist, and playlist views.
 ///
+/// The title is shown by the shared [`AppHeaderBar`](crate::app::components::AppHeaderBar),
+/// revealed once the artwork scrolls away via [`Self::connect_title_reveal`].
+///
 /// Structure (top to bottom):
 ///   ┌─────────────────────────────┐
-///   │ HeaderBarWidget (flat)      │  ← shows title when header scrolls away
-///   ├─────────────────────────────┤
 ///   │ ScrolledWindow              │
 ///   │  └─ Box (vertical)          │
 ///   │      ├─ Header (artwork)    │  ← scrolls naturally with content
@@ -33,7 +31,6 @@ pub struct DetailsPage {
     scrolled_window: gtk::ScrolledWindow,
     scroll_child: gtk::Box,
     header_area: gtk::Widget,
-    headerbar: Option<HeaderBarWidget>,
     header: DetailsHeader,
 }
 
@@ -49,17 +46,12 @@ impl DetailsPage {
     pub fn new(shape: HeaderImageShape, content: &impl IsA<gtk::Widget>) -> Self {
         Self::load_css();
 
-        // --- Headerbar (top bar that shows title when header is scrolled out of view) ---
-        let headerbar = HeaderBarWidget::new();
-        headerbar.add_classes(&["details__headerbar"]);
-
         // --- Header (artwork + title + action buttons) ---
         let header = DetailsHeader::new(shape);
         header.widget().add_css_class("details-header");
         header.widget().set_hexpand(true);
-        // BreakpointBin inside the header doesn't propagate child size requests,
-        // so we set a minimum height to ensure the header is visible in the ScrolledWindow.
-        header.widget().set_size_request(-1, HEADER_IMAGE_SIZE);
+        // The header widget reports its own natural height (see
+        // DetailsHeaderWidget::measure), so no height request is needed.
 
         let header_clamp = libadwaita::Clamp::new();
         header_clamp.set_maximum_size(CLAMP_MAX_SIZE);
@@ -96,27 +88,18 @@ impl DetailsPage {
         scrolled_window.add_css_class("details-page-scroll");
 
         // --- Assemble the page ---
-        let vbox = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        vbox.set_vexpand(true);
-        vbox.set_hexpand(true);
-        vbox.append(headerbar.upcast_ref::<gtk::Widget>());
-        vbox.append(&scrolled_window);
-
         let bin = libadwaita::Bin::new();
-        bin.set_child(Some(&vbox));
+        bin.set_child(Some(&scrolled_window));
 
         let header_area: gtk::Widget = window_handle.upcast();
 
-        let page = Self {
+        Self {
             widget: bin,
             scrolled_window,
             scroll_child,
             header_area,
-            headerbar: Some(headerbar),
             header,
-        };
-        page.connect_header_collapse();
-        page
+        }
     }
 
     // Accessors
@@ -129,31 +112,12 @@ impl DetailsPage {
         &self.header
     }
 
-    pub fn headerbar(&self) -> Option<&HeaderBarWidget> {
-        self.headerbar.as_ref()
-    }
-
-    /// Create a [`HeaderBarComponent`] bound to this page's headerbar widget.
-    /// The returned listener should be added to the page's children.
-    pub fn create_headerbar_listener(
-        &self,
-        model: Rc<impl HeaderBarModel + 'static>,
-    ) -> Box<dyn EventListener> {
-        Box::new(HeaderBarComponent::new(
-            self.headerbar().unwrap().clone(),
-            model,
-        ))
-    }
-
     // Content updates
 
-    /// Set title and subtitle on both the header widget and the collapsed headerbar.
+    /// Set title and subtitle on the header widget.
     pub fn set_details(&self, title: &str, subtitle: &str) {
         self.header.set_title(title);
         self.header.set_subtitle(subtitle);
-        if let Some(ref headerbar) = self.headerbar {
-            headerbar.set_title_and_subtitle(title, subtitle);
-        }
     }
 
     /// Asynchronously load artwork from an ImageSet, or mark the page as loaded if none.
@@ -169,10 +133,9 @@ impl DetailsPage {
                 if let (Some(scroll_child), Some(ref pixbuf)) = (weak.upgrade(), pixbuf) {
                     if let Some(header) = weak_header.upgrade() {
                         let texture = gdk::Texture::for_pixbuf(pixbuf);
-                        header.imp().image.set_paintable(Some(&texture));
-                        header
-                            .imp()
-                            .image_box
+                        let imp = header.imp();
+                        imp.image.set_paintable(Some(&texture));
+                        imp.image_box
                             .remove_css_class("details-header__image-placeholder");
                     }
                     scroll_child.add_css_class("details-page--loaded");
@@ -201,36 +164,30 @@ impl DetailsPage {
 
     // Internal wiring
 
-    /// When the header scrolls out of view, reveal the title in the headerbar
-    /// and remove the "flat" (transparent) style so it gets a solid background.
-    fn connect_header_collapse(&self) {
-        if let Some(ref headerbar) = self.headerbar {
-            headerbar.set_title_visible(false);
-            headerbar.add_classes(&["flat"]);
+    /// Reveal `title` in the shared header once the artwork scrolls out of
+    /// view, hiding it again at the top.
+    ///
+    /// Uses opacity, not `visible`: the shared header's `GtkStack` won't switch
+    /// to a child whose `visible` is false, so it stays visible but transparent.
+    pub fn connect_title_reveal(&self, title: &libadwaita::WindowTitle) {
+        title.set_opacity(0.0);
 
-            let header_visible = Rc::new(Cell::new(true));
-            let adj = self.scrolled_window.vadjustment();
-            let header_area = self.header_area.clone();
+        let title_shown = Rc::new(Cell::new(false));
+        let adj = self.scrolled_window.vadjustment();
+        let header_area = self.header_area.clone();
 
-            adj.connect_value_changed(clone!(
-                #[weak]
-                headerbar,
-                move |adj| {
-                    let (_, header_height, _, _) =
-                        header_area.measure(gtk::Orientation::Vertical, -1);
-                    let header_height = header_height as f64;
-                    let scrolled_past = header_height > 0.0 && adj.value() >= header_height * 0.5;
-                    if scrolled_past == header_visible.get() {
-                        header_visible.set(!scrolled_past);
-                        headerbar.set_title_visible(scrolled_past);
-                        if scrolled_past {
-                            headerbar.remove_classes(&["flat"]);
-                        } else {
-                            headerbar.add_classes(&["flat"]);
-                        }
-                    }
+        adj.connect_value_changed(clone!(
+            #[weak]
+            title,
+            move |adj| {
+                let (_, header_height, _, _) = header_area.measure(gtk::Orientation::Vertical, -1);
+                let header_height = header_height as f64;
+                let scrolled_past = header_height > 0.0 && adj.value() >= header_height * 0.5;
+                if scrolled_past != title_shown.get() {
+                    title_shown.set(scrolled_past);
+                    title.set_opacity(if scrolled_past { 1.0 } else { 0.0 });
                 }
-            ));
-        }
+            }
+        ));
     }
 }

--- a/src/app/dev_tools/dev_tools.blp
+++ b/src/app/dev_tools/dev_tools.blp
@@ -50,6 +50,19 @@ MenuButton dev_menu {
         Switch dev_debug_css_switch {}
       }
 
+      Box {
+        orientation: horizontal;
+        spacing: 8;
+
+        Label {
+          label: "Panel Sizes";
+          hexpand: true;
+          halign: start;
+        }
+
+        Switch dev_panel_sizes_switch {}
+      }
+
       Separator {}
 
       Label {

--- a/src/app/dev_tools/mod.rs
+++ b/src/app/dev_tools/mod.rs
@@ -9,6 +9,8 @@ use gtk::prelude::*;
 use std::cell::RefCell;
 use std::rc::Rc;
 
+mod panel_sizes;
+
 use super::state::{AppAction, AppModel};
 use crate::player::Command;
 
@@ -76,6 +78,10 @@ pub fn wire_dev_tools(
         }
         glib::Propagation::Proceed
     });
+
+    // Panel Sizes: overlay each major panel's pixel dimensions.
+    let dev_panel_sizes_switch: gtk::Switch = dev_builder.object("dev_panel_sizes_switch").unwrap();
+    panel_sizes::wire(builder, &dev_panel_sizes_switch);
 
     let dev_offline_switch: gtk::Switch = dev_builder.object("dev_offline_switch").unwrap();
     let player_sender = player_command_sender.clone();

--- a/src/app/dev_tools/panel_sizes.rs
+++ b/src/app/dev_tools/panel_sizes.rs
@@ -1,0 +1,133 @@
+//! Panel size overlay (debug builds only).
+//!
+//! Floats a colored box over each major panel, labelled with its pixel size.
+
+use gtk::cairo::{FontSlant, FontWeight};
+use gtk::prelude::*;
+use libadwaita::prelude::*;
+use std::cell::Cell;
+use std::rc::Rc;
+
+/// Panels to annotate, each a distinct RGB color. Names are widget ids from
+/// `window.blp`.
+const PANELS: [(&str, (f64, f64, f64)); 4] = [
+    ("sidebar_panel", (0.15, 0.70, 0.25)), // green: sidebar column
+    ("app_header", (0.90, 0.75, 0.10)),    // yellow: content header bar
+    ("navigation_stack", (0.60, 0.25, 0.85)), // purple: page stack
+    ("playback", (0.95, 0.20, 0.20)),      // red: playback bar
+];
+
+/// Set up the overlay and bind it to the "Panel Sizes" `switch`.
+pub fn wire(builder: &gtk::Builder, switch: &gtk::Switch) {
+    let window: libadwaita::ApplicationWindow = builder.object("window").unwrap();
+
+    // Reparent the content under an overlay so a transparent drawing area can
+    // sit on top without affecting layout.
+    let content = window.content();
+    window.set_content(None::<&gtk::Widget>);
+
+    let overlay = gtk::Overlay::new();
+    if let Some(child) = &content {
+        overlay.set_child(Some(child));
+    }
+
+    let area = gtk::DrawingArea::new();
+    area.set_can_target(false); // never intercept pointer input
+    area.set_can_focus(false);
+    area.set_visible(false);
+    overlay.add_overlay(&area);
+
+    window.set_content(Some(&overlay));
+
+    let enabled = Rc::new(Cell::new(false));
+
+    let builder_for_draw = builder.clone();
+    let enabled_for_draw = Rc::clone(&enabled);
+    area.set_draw_func(move |area, cr, _width, _height| {
+        if !enabled_for_draw.get() {
+            return;
+        }
+
+        for (index, (name, color)) in PANELS.iter().enumerate() {
+            let Some(widget) = builder_for_draw.object::<gtk::Widget>(*name) else {
+                continue;
+            };
+            // Skip panels not on screen, e.g. the sidebar when collapsed.
+            if !widget.is_mapped() {
+                continue;
+            }
+            let Some(bounds) = widget.compute_bounds(area) else {
+                continue;
+            };
+
+            // Inset more per nesting level so shared edges don't overlap.
+            let inset = index as f64 * 1.5 + 1.0;
+            let x = bounds.x() as f64 + inset;
+            let y = bounds.y() as f64 + inset;
+            let w = (bounds.width() as f64 - inset * 2.0).max(0.0);
+            let h = (bounds.height() as f64 - inset * 2.0).max(0.0);
+
+            // Bounding box.
+            cr.set_source_rgba(color.0, color.1, color.2, 0.6);
+            cr.set_line_width(2.0);
+            cr.rectangle(x, y, w, h);
+            let _ = cr.stroke();
+
+            // Size readout in application pixels.
+            let text = format!("W: {}px   H: {}px", widget.width(), widget.height());
+            cr.select_font_face("monospace", FontSlant::Normal, FontWeight::Bold);
+            cr.set_font_size(12.0);
+            let Ok(fe) = cr.font_extents() else {
+                continue;
+            };
+            let Ok(te) = cr.text_extents(&text) else {
+                continue;
+            };
+            let pad = 4.0;
+            let box_w = te.width() + pad * 2.0;
+            let box_h = fe.height() + pad * 2.0;
+
+            // Solid label background so text stays legible.
+            cr.set_source_rgba(color.0, color.1, color.2, 0.6);
+            cr.rectangle(x, y, box_w, box_h);
+            let _ = cr.fill();
+
+            cr.set_source_rgb(1.0, 1.0, 1.0);
+            cr.move_to(x + pad, y + pad + fe.ascent());
+            let _ = cr.show_text(&text);
+        }
+    });
+
+    // Repaint only when a panel size changes: hash all dimensions each frame
+    // and redraw when the hash moves.
+    let builder_for_tick = builder.clone();
+    let enabled_for_tick = Rc::clone(&enabled);
+    let last_signature: Cell<u64> = Cell::new(u64::MAX);
+    area.add_tick_callback(move |area, _clock| {
+        if enabled_for_tick.get() {
+            let mut signature: u64 = 0;
+            for (name, _) in PANELS.iter() {
+                if let Some(widget) = builder_for_tick.object::<gtk::Widget>(*name) {
+                    signature = signature
+                        .wrapping_mul(1_000_003)
+                        .wrapping_add(widget.width() as u64);
+                    signature = signature
+                        .wrapping_mul(1_000_003)
+                        .wrapping_add(widget.height() as u64);
+                }
+            }
+            if signature != last_signature.get() {
+                last_signature.set(signature);
+                area.queue_draw();
+            }
+        }
+        glib::ControlFlow::Continue
+    });
+
+    switch.connect_state_set(move |_, active| {
+        enabled.set(active);
+        area.set_visible(active);
+        area.queue_draw();
+        glib::Propagation::Proceed
+    });
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,6 +4,8 @@ use crate::auth::TokenStore;
 use crate::player::Command;
 use crate::settings::{RiffSettings, StateTracker};
 use futures::channel::mpsc::UnboundedSender;
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -118,6 +120,11 @@ impl App {
             sender.unbounded_send(action).unwrap();
         }
 
+        // The app-wide header bar and the registry screens contribute to it.
+        let app_header: AppHeaderBar = builder.object("app_header").unwrap();
+        let header_models: HeaderModelRegistry = Rc::new(RefCell::new(HashMap::new()));
+        let registrar = HeaderRegistrar::new(app_header.clone(), Rc::clone(&header_models));
+
         // All components that will be available initially
         let mut components: Vec<Box<dyn EventListener>> = vec![
             App::make_window(&self.settings, builder, Rc::clone(model)),
@@ -134,6 +141,15 @@ impl App {
                 Rc::clone(model),
                 dispatcher.box_clone(),
                 worker.clone(),
+                registrar,
+            ),
+            // After navigation, so a pushed screen registers before the header
+            // refreshes.
+            App::make_app_header(
+                app_header,
+                Rc::clone(model),
+                dispatcher.box_clone(),
+                header_models,
             ),
             App::make_search_button(builder, dispatcher.box_clone()),
             App::make_clipboard_import(builder, Rc::clone(model), dispatcher.box_clone()),
@@ -165,6 +181,18 @@ impl App {
         Box::new(MainWindow::new(settings.window.clone(), app_model, window))
     }
 
+    // The app-wide header bar shared by every content screen.
+    fn make_app_header(
+        widget: AppHeaderBar,
+        app_model: Rc<AppModel>,
+        dispatcher: Box<dyn ActionDispatcher>,
+        models: HeaderModelRegistry,
+    ) -> Box<AppHeaderBarComponent> {
+        Box::new(AppHeaderBarComponent::new(
+            widget, app_model, dispatcher, models,
+        ))
+    }
+
     fn make_inhibitor(builder: &gtk::Builder, app_model: Rc<AppModel>) -> Box<impl EventListener> {
         let window: libadwaita::ApplicationWindow = builder.object("window").unwrap();
         Box::new(crate::inhibitor::SuspendInhibitor::new(window, app_model))
@@ -175,20 +203,28 @@ impl App {
         app_model: Rc<AppModel>,
         dispatcher: Box<dyn ActionDispatcher>,
         worker: Worker,
+        registrar: HeaderRegistrar,
     ) -> Box<Navigation> {
         let split_view: libadwaita::NavigationSplitView = builder.object("split_view").unwrap();
         let navigation_stack: gtk::Stack = builder.object("navigation_stack").unwrap();
         let home_listbox: gtk::ListBox = builder.object("home_listbox").unwrap();
+        let window: libadwaita::ApplicationWindow = builder.object("window").unwrap();
+
         let model = NavigationModel::new(Rc::clone(&app_model), dispatcher.box_clone());
         // This is where components that are not created initially will be assembled
-        let screen_factory =
-            ScreenFactory::new(Rc::clone(&app_model), dispatcher.box_clone(), worker);
+        let screen_factory = ScreenFactory::new(
+            Rc::clone(&app_model),
+            dispatcher.box_clone(),
+            worker,
+            registrar,
+        );
         Box::new(Navigation::new(
             model,
             split_view,
             navigation_stack,
             home_listbox,
             screen_factory,
+            window,
         ))
     }
 
@@ -219,6 +255,7 @@ impl App {
         Box::new(PlaybackControl::new(
             model,
             builder.object("playback").unwrap(),
+            builder.object("mobile_now_playing").unwrap(),
             worker,
         ))
     }

--- a/src/app/models/card_enums.rs
+++ b/src/app/models/card_enums.rs
@@ -93,9 +93,9 @@ impl CardSize {
     /// Returns the pixel dimension for this size variant.
     pub fn pixel_size(self) -> i32 {
         match self {
-            Self::Small => 100,
+            Self::Small => 90,
             Self::Medium => 140,
-            Self::Large => 180,
+            Self::Large => 200,
         }
     }
 

--- a/src/app/state/app_state.rs
+++ b/src/app/state/app_state.rs
@@ -26,7 +26,6 @@ pub enum AppAction {
     Raise,
     ShowNotification(String),
     SetConnectionLost(bool),
-    ViewNowPlaying,
     // Cross-state actions
     QueueSelection,
     DequeueSelection,
@@ -98,7 +97,6 @@ pub enum AppEvent {
     NotificationShown(String),
     ConnectionLostChanged(bool),
     PlaylistCreatedNotificationShown(String),
-    NowPlayingShown,
     SettingsEvent(SettingsEvent),
 }
 
@@ -149,7 +147,6 @@ impl AppState {
                     vec![AppEvent::ConnectionLostChanged(lost)]
                 }
             }
-            AppAction::ViewNowPlaying => vec![AppEvent::NowPlayingShown],
             AppAction::Raise => vec![AppEvent::Raised],
             // Cross-state actions: multiple "substates" are affected by these actions, that's why they're handled here
             // Might need some clean-up

--- a/src/app/state/browser_state.rs
+++ b/src/app/state/browser_state.rs
@@ -295,8 +295,16 @@ impl BrowserState {
         self.navigation.current().name()
     }
 
+    /// Whether a back button should be offered for the current screen.
+    ///
+    /// Only pushed detail screens (artist, album, playlist, user) get one.
+    /// Home sub-pages share the "home" screen, so there is nowhere to go back.
+    /// Search lives on the stack but is treated as top-level, so no back button.
     pub fn can_pop(&self) -> bool {
-        self.navigation.can_pop() || self.navigation_hidden
+        if matches!(self.current_screen(), ScreenName::Search) {
+            return false;
+        }
+        self.navigation.can_pop()
     }
 
     pub fn count(&self) -> usize {

--- a/src/debug.css
+++ b/src/debug.css
@@ -48,7 +48,7 @@
   border: 2px solid rgba(0, 100, 255, 0.6);
 }
 
-.details-header > breakpointbin > box > centerbox {
+.details-header > breakpointbin > box > box {
   background-color: rgba(150, 0, 255, 0.08);
   border: 2px solid rgba(150, 0, 255, 0.4);
 }

--- a/src/riff.gresource.xml
+++ b/src/riff.gresource.xml
@@ -45,7 +45,7 @@
     <!-- selection -->
     <file alias="components/selection_toolbar.ui">app/components/widgets/selection/selection_toolbar.ui</file>
     <file alias="components/selection_toolbar.css">app/components/widgets/selection/selection_toolbar.css</file>
-    <!-- headerbar -->
+    <!-- app header -->
     <file alias="components/headerbar.ui">app/components/shell/headerbar/headerbar.ui</file>
     <!-- sidebar -->
     <file alias="sidebar/sidebar_row.ui">app/components/shell/sidebar/sidebar_row.ui</file>

--- a/src/window.blp
+++ b/src/window.blp
@@ -6,16 +6,23 @@ Adw.ApplicationWindow window {
   default-height: 720;
 
   Adw.Breakpoint {
+    condition("max-width:764sp")
+
+    setters {
+      mobile_now_playing_container.visible: true;
+    }
+  }
+
+  Adw.Breakpoint {
     condition("max-width:550sp")
 
     setters {
+      mobile_now_playing_container.visible: true;
       split_view.collapsed: true;
     }
   }
 
-  Box {
-    orientation: vertical;
-
+  $ShellBox {
     ShortcutController {
       scope: local;
 
@@ -59,7 +66,7 @@ Adw.ApplicationWindow window {
         sidebar: Adw.NavigationPage {
           title: "Sidebar";
 
-          child: Box {
+          child: Box sidebar_panel {
             orientation: vertical;
 
             Adw.HeaderBar sidebar_header {
@@ -105,6 +112,9 @@ Adw.ApplicationWindow window {
           child: Box {
             orientation: vertical;
 
+            $AppHeaderBar app_header {
+            }
+
             Stack navigation_stack {
               hexpand: true;
               vexpand: true;
@@ -114,11 +124,30 @@ Adw.ApplicationWindow window {
         };
       }
     }
+
+    // Trailing children of ShellBox, pinned to the bottom at fixed height.
+    // See shell/window/shell_box.rs.
+    Box mobile_now_playing_container {
+      visible: false;
+      hexpand: true;
+
+      $PlaybackInfoMobileWidget mobile_now_playing {
+        visible: false;
+        hexpand: true;
+        height-request: 36;
+
+        styles [
+          "mobile-now-playing",
+        ]
+      }
+    }
+
     Overlay {
       hexpand: true;
 
       $PlaybackWidget playback {
         hexpand: "1";
+        vexpand: false;
       }
 
       [overlay]


### PR DESCRIPTION
### Changes
The focus of this PR is to make Riff feel better on smaller screens and improve the transition from wide to narrow on desktop.

The mobile playback bar was redesigned to align with the desktop version, so resizing the window no longer causes pop-in or bad transitions. Its height is now fixed to keep short windows from cropping the controls or hiding the bar.

The detail page header was updated to support a vertical layout, with the image above the title text and buttons.

The sidebar on small screens now has a toggle to show or hide it, letting users dive into their collection and quickly return to the library or home screen. On desktop, the same toggle hides the sidebar, and when moving from wide to narrow the content page takes priority.

Other small changes improve mobile navigation and polish the app before the 26.07 launch.

### Related Issues

- https://github.com/Diegovsky/riff/issues/36
- https://github.com/Diegovsky/riff/issues/102
- https://github.com/Diegovsky/riff/issues/103
