### PR TITLE
Added DRM Notice and Better Handling for Unplayable Tracks

### DIFF
--- a/data/dev.diegovsky.Riff.gschema.xml
+++ b/data/dev.diegovsky.Riff.gschema.xml
@@ -275,5 +275,9 @@
       <default>'recently-added'</default>
       <summary>Sort order for saved artists page</summary>
     </key>
+    <key name='drm-verified-user' type='s'>
+      <default>''</default>
+      <summary>Spotify user id known to play tracks, used to skip PlayPlay DRM detection across restarts.</summary>
+    </key>
   </schema>
 </schemalist>

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -5,11 +5,13 @@ src/app/components/device_selector/widget.rs
 src/app/components/labels.rs
 src/app/components/widgets/card/widget.rs
 src/app/components/widgets/card_list/card_view_menu.rs
+src/app/components/widgets/playlist/song.rs
 src/app/models/card_enums.rs
 src/app/components/mod.rs
 src/app/components/navigation/factory.rs
 src/app/components/notification/mod.rs
 src/app/components/shell/clipboard_import/mod.rs
+src/app/components/shell/window/mod.rs
 src/app/components/pages/details_artist/widget.rs
 src/app/components/pages/details_playlist/model.rs
 src/app/components/pages/details_user/model.rs
@@ -28,6 +30,7 @@ src/app/components/sidebar/sidebar.rs
 src/app/components/user_menu/user_menu.rs
 src/app/state/login_state.rs
 src/connect/player.rs
+src/player/mod.rs
 src/main.rs
 
 # find src -name "*.blp" -print

--- a/src/api/api_models.rs
+++ b/src/api/api_models.rs
@@ -391,6 +391,9 @@ pub struct AlbumTrackItem {
     pub artists: Vec<Artist>,
     #[serde(default)]
     pub explicit: bool,
+    /// Only set on market-scoped requests (track relinking); None if not reported.
+    #[serde(default)]
+    pub is_playable: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -534,6 +537,7 @@ where
                     duration_ms,
                     track_number,
                     explicit,
+                    is_playable,
                 } = track;
                 let artists = artists
                     .into_iter()
@@ -566,6 +570,7 @@ where
                     duration_ms: duration_ms as u32,
                     art,
                     explicit,
+                    playable: is_playable.unwrap_or(true),
                 })
             })
             .collect();
@@ -800,5 +805,31 @@ mod tests {
         assert_eq!(song.id, "track123");
         assert_eq!(song.album.id, "album456");
         assert_eq!(song.title, "Some Song");
+        // No `is_playable` in the payload defaults to playable.
+        assert!(song.playable);
+    }
+
+    #[test]
+    fn test_unplayable_track_maps_to_not_playable() {
+        // Market-scoped request for a region-restricted track: is_playable is false.
+        let track = r#"{
+            "id": "track123",
+            "uri": "spotify:track:track123",
+            "name": "Some Song",
+            "duration_ms": 210000,
+            "track_number": 3,
+            "is_playable": false,
+            "restrictions": {"reason": "market"},
+            "artists": [{"id": "artist1", "name": "Artist"}],
+            "album": {
+                "id": "album456",
+                "name": "Some Album",
+                "artists": [{"id": "artist1", "name": "Artist"}],
+                "images": [{"height": 64, "url": "http://img", "width": 64}]
+            }
+        }"#;
+        let deserialized: TrackItem = serde_json::from_str(track).unwrap();
+        let song: SongDescription = deserialized.into();
+        assert!(!song.playable);
     }
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -445,9 +445,12 @@ impl SpotifyClient {
     }
 
     pub(crate) fn get_album(&self, id: &str) -> SpotifyRequest<'_, (), FullAlbum> {
+        let query = make_query_params()
+            .append_pair("market", "from_token")
+            .finish();
         self.request()
             .method(Method::GET)
-            .uri(format!("/v1/albums/{id}"), None)
+            .uri(format!("/v1/albums/{id}"), Some(&query))
     }
 
     pub(crate) fn get_track(&self, id: &str) -> SpotifyRequest<'_, (), TrackItem> {
@@ -466,6 +469,7 @@ impl SpotifyClient {
         limit: usize,
     ) -> SpotifyRequest<'_, (), Page<AlbumTrackItem>> {
         let query = make_query_params()
+            .append_pair("market", "from_token")
             .append_pair("offset", &offset.to_string()[..])
             .append_pair("limit", &limit.to_string()[..])
             .finish();
@@ -566,6 +570,7 @@ impl SpotifyClient {
         limit: usize,
     ) -> SpotifyRequest<'_, (), Page<SavedAlbum>> {
         let query = make_query_params()
+            .append_pair("market", "from_token")
             .append_pair("offset", &offset.to_string()[..])
             .append_pair("limit", &limit.to_string()[..])
             .finish();
@@ -581,6 +586,7 @@ impl SpotifyClient {
         limit: usize,
     ) -> SpotifyRequest<'_, (), Page<SavedTrack>> {
         let query = make_query_params()
+            .append_pair("market", "from_token")
             .append_pair("offset", &offset.to_string()[..])
             .append_pair("limit", &limit.to_string()[..])
             .finish();

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -25,6 +25,7 @@ pub async fn clear_user_cache() -> Option<()> {
 
 /// Result of checking the user's profile at login time.
 pub struct UserProfileCheck {
+    pub user_id: String,
     pub is_premium: bool,
     pub explicit_filter_enabled: bool,
     pub explicit_filter_locked: bool,
@@ -79,6 +80,7 @@ pub async fn check_user_profile(token: &str) -> Result<UserProfileCheck, Spotify
     };
 
     Ok(UserProfileCheck {
+        user_id: user.id,
         is_premium,
         explicit_filter_enabled,
         explicit_filter_locked,

--- a/src/app/components/pages/now_playing/model.rs
+++ b/src/app/components/pages/now_playing/model.rs
@@ -237,6 +237,10 @@ impl PlaylistModel for NowPlayingModel {
         self.base.toggle_song_like(&songs, id);
     }
 
+    fn skip_explicit(&self) -> bool {
+        self.base.skip_explicit()
+    }
+
     fn actions_for(&self, song: &SongDescription) -> Option<gio::ActionGroup> {
         let group = SimpleActionGroup::new();
         for a in song.make_artist_actions(self.dispatcher.box_clone(), None) {

--- a/src/app/components/shell/window/mod.rs
+++ b/src/app/components/shell/window/mod.rs
@@ -132,6 +132,24 @@ impl MainWindow {
         );
     }
 
+    fn show_drm_blocked_dialog(&self) {
+        let dialog = libadwaita::AlertDialog::new(Some(&gettext("Playback Not Available")), None);
+
+        dialog.set_body(&gettext(
+            "This account appears to be using Spotify's new PlayPlay DRM, which \
+             prevents playback in Riff. Spotify's PlayPlay DRM is proprietary and only works in \
+             the official Spotify client.\n\n\
+             This is not a bug and Riff will never attempt to circumvent Spotify's PlayPlay DRM.",
+        ));
+
+        dialog.add_response("close", &gettext("Dismiss"));
+        dialog.set_default_response(Some("close"));
+        dialog.set_close_response("close");
+        dialog.set_prefer_wide_layout(true);
+
+        dialog.present(Some(&self.window));
+    }
+
     fn start(&self) {
         self.window.set_default_size(
             self.initial_window_geometry.width,
@@ -166,6 +184,7 @@ impl EventListener for MainWindow {
         match event {
             AppEvent::Started => self.start(),
             AppEvent::Raised => self.raise(),
+            AppEvent::DrmBlockedDialogShown => self.show_drm_blocked_dialog(),
             _ => {}
         }
     }

--- a/src/app/components/widgets/details_page/model.rs
+++ b/src/app/components/widgets/details_page/model.rs
@@ -37,6 +37,9 @@ macro_rules! impl_playlist_model_base {
             let songs = PlaylistModel::song_list_model(self);
             self.base.toggle_song_like(&songs, id);
         }
+        fn skip_explicit(&self) -> bool {
+            self.base.skip_explicit()
+        }
     };
 }
 
@@ -127,6 +130,10 @@ impl DetailsPageModel {
 
     pub fn current_song_id(&self) -> Option<String> {
         self.state().playback.current_song_id()
+    }
+
+    pub fn skip_explicit(&self) -> bool {
+        self.state().playback.skip_explicit()
     }
 
     // Selection helpers
@@ -386,6 +393,7 @@ mod tests {
             art: None,
             track_number: None,
             explicit: false,
+            playable: true,
         }
     }
 

--- a/src/app/components/widgets/playlist/playlist.rs
+++ b/src/app/components/widgets/playlist/playlist.rs
@@ -56,6 +56,10 @@ pub trait PlaylistModel {
 
     fn toggle_song_like(&self, _id: &str) {}
 
+    fn skip_explicit(&self) -> bool {
+        false
+    }
+
     fn song_state(&self, id: &str) -> SongState {
         let is_playing = self.current_song_id().map(|s| s.eq(id)).unwrap_or(false);
         let is_selected = self
@@ -63,10 +67,19 @@ pub trait PlaylistModel {
             .map(|s| s.is_song_selected(id))
             .unwrap_or(false);
         let is_liked = self.is_song_liked(id);
+        let is_explicit_filtered = if self.skip_explicit() {
+            self.song_list_model()
+                .get(id)
+                .map(|m| m.description().explicit)
+                .unwrap_or(false)
+        } else {
+            false
+        };
         SongState {
             is_selected,
             is_playing,
             is_liked,
+            is_explicit_filtered,
         }
     }
 
@@ -304,11 +317,13 @@ impl SongModel {
             is_playing,
             is_selected,
             is_liked,
+            is_explicit_filtered,
         }: SongState,
     ) {
         self.set_playing(is_playing);
         self.set_selected(is_selected);
         self.set_liked(is_liked);
+        self.set_explicit_filtered(is_explicit_filtered);
     }
 }
 
@@ -356,6 +371,10 @@ where
                 | BrowserEvent::ArtistDetailsUpdated(_)
                 | BrowserEvent::UserDetailsUpdated(_),
             ) => {
+                self.seed_song_states();
+            }
+            // Re-seed so songs pick up the new explicit-filtered state.
+            AppEvent::PlaybackEvent(PlaybackEvent::SkipExplicitChanged(_)) => {
                 self.seed_song_states();
             }
             _ => {}

--- a/src/app/components/widgets/playlist/song.css
+++ b/src/app/components/widgets/playlist/song.css
@@ -156,6 +156,14 @@ row:hover .song__like:hover {
   font-weight: bold;
 }
 
+/* Dim unplayable tracks (e.g. region locked); context menu stays usable. */
+.song--unplayable label.title,
+.song--unplayable label.subtitle,
+.song--unplayable .song__index,
+.song--unplayable .song__cover {
+  opacity: 0.4;
+}
+
 /* "Context Menu" */
 .song__menu {
   opacity: 0;

--- a/src/app/components/widgets/playlist/song.rs
+++ b/src/app/components/widgets/playlist/song.rs
@@ -3,6 +3,7 @@ use crate::app::loader::ImageLoader;
 use crate::app::models::SongModel;
 use crate::app::Worker;
 use gdk::Rectangle;
+use gettextrs::gettext;
 use gio::MenuModel;
 use glib::subclass::InitializingObject;
 
@@ -17,6 +18,7 @@ mod imp {
 
     const SONG_CLASS: &str = "song--playing";
     const LIKED_CLASS: &str = "song--liked";
+    const UNPLAYABLE_CLASS: &str = "song--unplayable";
 
     #[derive(Debug, Default, CompositeTemplate)]
     #[template(resource = "/dev/diegovsky/Riff/components/song.ui")]
@@ -49,6 +51,8 @@ mod imp {
         pub song_cover: TemplateChild<gtk::Image>,
 
         pub like_handler_id: std::cell::RefCell<Option<glib::SignalHandlerId>>,
+        pub explicit_filtered: std::cell::Cell<bool>,
+        pub playable: std::cell::Cell<bool>,
     }
 
     #[glib::object_subclass]
@@ -67,10 +71,15 @@ mod imp {
     }
 
     lazy_static! {
-        static ref PROPERTIES: [glib::ParamSpec; 3] = [
+        static ref PROPERTIES: [glib::ParamSpec; 5] = [
             glib::ParamSpecBoolean::builder("playing").build(),
             glib::ParamSpecBoolean::builder("selected").build(),
-            glib::ParamSpecBoolean::builder("liked").build()
+            glib::ParamSpecBoolean::builder("liked").build(),
+            // Defaults to true so unset widgets render as playable.
+            glib::ParamSpecBoolean::builder("playable")
+                .default_value(true)
+                .build(),
+            glib::ParamSpecBoolean::builder("explicit-filtered").build(),
         ];
     }
 
@@ -111,6 +120,42 @@ mod imp {
                         self.like_btn.set_tooltip_text(Some("Like"));
                     }
                 }
+                "playable" => {
+                    let is_playable: bool = value
+                        .get()
+                        .expect("type conformity checked by `Object::set_property`");
+                    self.playable.set(is_playable);
+                    // Explicit-filtered takes visual priority.
+                    if !self.explicit_filtered.get() {
+                        if is_playable {
+                            self.obj().remove_css_class(UNPLAYABLE_CLASS);
+                            self.obj().set_tooltip_text(None);
+                        } else {
+                            self.obj().add_css_class(UNPLAYABLE_CLASS);
+                            self.obj()
+                                .set_tooltip_text(Some(&gettext("Not Available in Your Region")));
+                        }
+                    }
+                }
+                "explicit-filtered" => {
+                    let is_filtered: bool = value
+                        .get()
+                        .expect("type conformity checked by `Object::set_property`");
+                    self.explicit_filtered.set(is_filtered);
+                    if is_filtered {
+                        self.obj().add_css_class(UNPLAYABLE_CLASS);
+                        self.obj()
+                            .set_tooltip_text(Some(&gettext("Explicit Content is Disabled")));
+                    } else if self.playable.get() {
+                        self.obj().remove_css_class(UNPLAYABLE_CLASS);
+                        self.obj().set_tooltip_text(None);
+                    } else {
+                        // Still region-locked.
+                        self.obj().add_css_class(UNPLAYABLE_CLASS);
+                        self.obj()
+                            .set_tooltip_text(Some(&gettext("Not Available in Your Region")));
+                    }
+                }
                 _ => unimplemented!(),
             }
         }
@@ -120,6 +165,8 @@ mod imp {
                 "playing" => self.obj().has_css_class(SONG_CLASS).to_value(),
                 "selected" => self.song_checkbox.is_active().to_value(),
                 "liked" => self.obj().has_css_class(LIKED_CLASS).to_value(),
+                "playable" => self.playable.get().to_value(),
+                "explicit-filtered" => self.explicit_filtered.get().to_value(),
                 _ => unimplemented!(),
             }
         }
@@ -127,6 +174,7 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
             self.song_checkbox.set_sensitive(false);
+            self.playable.set(true);
         }
 
         fn dispose(&self) {
@@ -181,7 +229,6 @@ impl SongWidget {
     /// Note: coordinates are assumed to be relative to the widget.
     pub fn show_menu(&self, x: f64, y: f64) {
         let widget = self.imp();
-        let root = self.root().unwrap();
 
         let point = self
             .compute_point(&widget.menu_btn.get(), &Point::zero())
@@ -259,6 +306,8 @@ impl SongWidget {
         model.bind_playing(self, "playing");
         model.bind_selected(self, "selected");
         model.bind_liked(self, "liked");
+        model.bind_playable(self, "playable");
+        model.bind_explicit_filtered(self, "explicit-filtered");
 
         self.set_show_cover(show_cover);
         if show_cover {

--- a/src/app/dev_tools/dev_tools.blp
+++ b/src/app/dev_tools/dev_tools.blp
@@ -135,6 +135,11 @@ MenuButton dev_menu {
         styles ["destructive-action"]
       }
 
+      Button dev_simulate_unavailable {
+        label: "Simulate Unavailable Track";
+        tooltip-text: "Inject one 'track failed to load' event; click repeatedly to trip the stop threshold";
+      }
+
       Separator {}
 
       Label {
@@ -153,6 +158,16 @@ MenuButton dev_menu {
 
       Button dev_dump_state {
         label: "Dump State to Log";
+      }
+
+      Button dev_reset_drm {
+        label: "Reset DRM Verification";
+        tooltip-text: "Forget that this account has played a track and re-arm PlayPlay DRM detection";
+      }
+
+      Button dev_show_drm_dialog {
+        label: "Show DRM Warning";
+        tooltip-text: "Pop up the PlayPlay DRM \"Playback Not Available\" dialog";
       }
     };
   };

--- a/src/app/dev_tools/mod.rs
+++ b/src/app/dev_tools/mod.rs
@@ -115,6 +115,13 @@ pub fn wire_dev_tools(
         let _ = player_sender.unbounded_send(Command::DevKillSession);
     });
 
+    let dev_simulate_unavailable: gtk::Button =
+        dev_builder.object("dev_simulate_unavailable").unwrap();
+    let player_sender = player_command_sender.clone();
+    dev_simulate_unavailable.connect_clicked(move |_| {
+        let _ = player_sender.unbounded_send(Command::DevSimulateTrackUnavailable);
+    });
+
     // Inject API Error: force every Spotify Web API request to fail with
     // the selected error. Uses toggle buttons instead of a DropDown to
     // avoid a GTK4 bug where a DropDown inside a Popover breaks the
@@ -239,5 +246,19 @@ pub fn wire_dev_tools(
             playback.songs().len()
         );
         info!("==== END STATE DUMP ====");
+    });
+
+    // Clear the persisted verified marker and re-arm DRM detection.
+    let dev_reset_drm: gtk::Button = dev_builder.object("dev_reset_drm").unwrap();
+    let player_sender = player_command_sender.clone();
+    dev_reset_drm.connect_clicked(move |_| {
+        let _ = player_sender.unbounded_send(Command::DevResetDrmVerification);
+    });
+
+    // Show the DRM dialog on demand.
+    let dev_show_drm_dialog: gtk::Button = dev_builder.object("dev_show_drm_dialog").unwrap();
+    let app_sender = sender.clone();
+    dev_show_drm_dialog.connect_clicked(move |_| {
+        let _ = app_sender.unbounded_send(AppAction::ShowDrmBlockedDialog);
     });
 }

--- a/src/app/models/main.rs
+++ b/src/app/models/main.rs
@@ -223,6 +223,7 @@ pub struct SongDescription {
     pub duration_ms: u32,
     pub art: Option<ImageSet>,
     pub explicit: bool,
+    pub playable: bool,
 }
 
 impl SongDescription {
@@ -246,6 +247,7 @@ pub struct SongState {
     pub is_playing: bool,
     pub is_selected: bool,
     pub is_liked: bool,
+    pub is_explicit_filtered: bool,
 }
 
 // A batch of SONGS
@@ -373,6 +375,7 @@ mod tests {
             art: None,
             track_number: None,
             explicit: false,
+            playable: true,
         }
     }
 

--- a/src/app/models/songs/song_model.rs
+++ b/src/app/models/songs/song_model.rs
@@ -31,6 +31,10 @@ impl SongModel {
         self.set_property("liked", is_liked);
     }
 
+    pub fn set_explicit_filtered(&self, is_explicit_filtered: bool) {
+        self.set_property("explicit-filtered", is_explicit_filtered);
+    }
+
     pub fn get_playing(&self) -> bool {
         self.property("playing")
     }
@@ -103,6 +107,22 @@ impl SongModel {
         );
     }
 
+    pub fn bind_playable(&self, o: &impl ObjectType, property: &str) {
+        self.imp().push_binding(
+            self.bind_property("playable", o, property)
+                .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE)
+                .build(),
+        );
+    }
+
+    pub fn bind_explicit_filtered(&self, o: &impl ObjectType, property: &str) {
+        self.imp().push_binding(
+            self.bind_property("explicit-filtered", o, property)
+                .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE)
+                .build(),
+        );
+    }
+
     pub fn unbind_all(&self) {
         self.imp().unbind_all(self);
     }
@@ -166,7 +186,7 @@ mod imp {
     }
 
     lazy_static! {
-        static ref PROPERTIES: [glib::ParamSpec; 9] = [
+        static ref PROPERTIES: [glib::ParamSpec; 11] = [
             glib::ParamSpecString::builder("id").read_only().build(),
             glib::ParamSpecUInt::builder("index").read_only().build(),
             glib::ParamSpecString::builder("title").read_only().build(),
@@ -186,6 +206,12 @@ mod imp {
             glib::ParamSpecBoolean::builder("liked")
                 .readwrite()
                 .build(),
+            glib::ParamSpecBoolean::builder("playable")
+                .read_only()
+                .build(),
+            glib::ParamSpecBoolean::builder("explicit-filtered")
+                .readwrite()
+                .build(),
         ];
     }
 
@@ -203,12 +229,14 @@ mod imp {
                     let SongState {
                         is_selected,
                         is_liked,
+                        is_explicit_filtered,
                         ..
                     } = self.state.get();
                     self.state.set(SongState {
                         is_playing,
                         is_selected,
                         is_liked,
+                        is_explicit_filtered,
                     });
                 }
                 "selected" => {
@@ -218,12 +246,14 @@ mod imp {
                     let SongState {
                         is_playing,
                         is_liked,
+                        is_explicit_filtered,
                         ..
                     } = self.state.get();
                     self.state.set(SongState {
                         is_playing,
                         is_selected,
                         is_liked,
+                        is_explicit_filtered,
                     });
                 }
                 "liked" => {
@@ -233,12 +263,31 @@ mod imp {
                     let SongState {
                         is_playing,
                         is_selected,
+                        is_explicit_filtered,
                         ..
                     } = self.state.get();
                     self.state.set(SongState {
                         is_playing,
                         is_selected,
                         is_liked,
+                        is_explicit_filtered,
+                    });
+                }
+                "explicit-filtered" => {
+                    let is_explicit_filtered = value
+                        .get()
+                        .expect("type conformity checked by `Object::set_property`");
+                    let SongState {
+                        is_playing,
+                        is_selected,
+                        is_liked,
+                        ..
+                    } = self.state.get();
+                    self.state.set(SongState {
+                        is_playing,
+                        is_selected,
+                        is_liked,
+                        is_explicit_filtered,
                     });
                 }
                 _ => unimplemented!(),
@@ -296,6 +345,14 @@ mod imp {
                 "playing" => self.state.get().is_playing.to_value(),
                 "selected" => self.state.get().is_selected.to_value(),
                 "liked" => self.state.get().is_liked.to_value(),
+                "playable" => self
+                    .song
+                    .borrow()
+                    .as_ref()
+                    .expect("song set at constructor")
+                    .playable
+                    .to_value(),
+                "explicit-filtered" => self.state.get().is_explicit_filtered.to_value(),
                 _ => unimplemented!(),
             }
         }

--- a/src/app/models/songs/support.rs
+++ b/src/app/models/songs/support.rs
@@ -470,6 +470,7 @@ mod tests {
             art: None,
             track_number: None,
             explicit: false,
+            playable: true,
         }
     }
 

--- a/src/app/state/app_state.rs
+++ b/src/app/state/app_state.rs
@@ -25,6 +25,8 @@ pub enum AppAction {
     Start,
     Raise,
     ShowNotification(String),
+    // Account is blocked by PlayPlay DRM; triggers an explanatory dialog.
+    ShowDrmBlockedDialog,
     SetConnectionLost(bool),
     // Cross-state actions
     QueueSelection,
@@ -95,6 +97,7 @@ pub enum AppEvent {
     Started,
     Raised,
     NotificationShown(String),
+    DrmBlockedDialogShown,
     ConnectionLostChanged(bool),
     PlaylistCreatedNotificationShown(String),
     SettingsEvent(SettingsEvent),
@@ -136,6 +139,7 @@ impl AppState {
             // Couple of actions that don't mutate the state (not intested in keeping track of what they change)
             // they're here just to have a consistent way of doing things (always an Action)
             AppAction::ShowNotification(c) => vec![AppEvent::NotificationShown(c)],
+            AppAction::ShowDrmBlockedDialog => vec![AppEvent::DrmBlockedDialogShown],
             AppAction::SetConnectionLost(lost) => {
                 // Real state, deduplicated: only emit the event (and move the
                 // banner) when the connection status actually changes, so

--- a/src/app/state/playback_state.rs
+++ b/src/app/state/playback_state.rs
@@ -48,6 +48,10 @@ impl PlaybackState {
         self.explicit_filter_locked
     }
 
+    pub fn skip_explicit(&self) -> bool {
+        self.skip_explicit
+    }
+
     pub fn repeat_mode(&self) -> RepeatMode {
         self.repeat
     }
@@ -209,31 +213,27 @@ impl PlaybackState {
         })
     }
 
-    /// Advance to the next non-explicit track. If skip_explicit is enabled,
-    /// keeps skipping forward until a non-explicit track is found or no more
-    /// tracks remain. Always calls self.stop() before returning None.
-    fn play_next_skipping_explicit(&mut self) -> Option<String> {
-        if !self.skip_explicit {
-            return self.play_next();
-        }
-
-        // Limit iterations to avoid infinite loops in repeat mode with all-explicit playlists
-        let max_skips = self.songs.len();
+    /// Advance to the next playable track. Unplayable tracks are always
+    /// skipped; explicit tracks only when skip_explicit is on. Stops before
+    /// returning None.
+    fn play_next_skippable(&mut self) -> Option<String> {
+        // Cap iterations to avoid looping forever when all tracks are skippable;
+        // len() can under-report, so fall back to partial_len and at least 1.
+        let max_skips = self.songs.len().max(self.songs.partial_len()).max(1);
         for _ in 0..max_skips {
             let id = match self.play_next() {
                 Some(id) => id,
                 None => {
-                    // No more tracks available - stop playback
                     self.stop();
                     return None;
                 }
             };
-            if !self.current_song_is_explicit() {
+            if !self.current_song_should_skip() {
                 return Some(id);
             }
-            debug!("Skipping explicit track '{}'", id);
+            debug!("Skipping track '{}' (unplayable or explicit-filtered)", id);
         }
-        // All remaining tracks are explicit - stop playback
+        // Nothing left to play.
         self.stop();
         None
     }
@@ -243,17 +243,26 @@ impl PlaybackState {
         self.current_song().map(|s| s.explicit).unwrap_or(false)
     }
 
-    /// If skipping is enabled and the current track is explicit, advance to the
-    /// next non-explicit track. Used when the filter is turned on (locally or by
-    /// the account) while an explicit track is already playing. Returns the
-    /// playback events to emit, if any.
-    fn skip_current_if_explicit(&mut self) -> Vec<PlaybackEvent> {
-        if self.skip_explicit && self.current_song_is_explicit() {
-            debug!("Filter enabled while an explicit track is current; skipping");
-            if let Some(next_id) = self.play_next_skipping_explicit() {
+    /// True if the current song is not playable (e.g. region locked).
+    fn current_song_is_unplayable(&self) -> bool {
+        self.current_song().map(|s| !s.playable).unwrap_or(false)
+    }
+
+    /// True if the current song must be skipped: unplayable, or explicit while
+    /// skip_explicit is on.
+    fn current_song_should_skip(&self) -> bool {
+        self.current_song_is_unplayable() || (self.skip_explicit && self.current_song_is_explicit())
+    }
+
+    /// If the current track must be skipped, advance to the next playable one.
+    /// Returns the playback events to emit, if any.
+    fn skip_current_if_needed(&mut self) -> Vec<PlaybackEvent> {
+        if self.current_song_should_skip() {
+            debug!("Current track must be skipped (unplayable or explicit-filtered)");
+            if let Some(next_id) = self.play_next_skippable() {
                 vec![PlaybackEvent::TrackChanged(next_id)]
             } else {
-                // play_next_skipping_explicit already called self.stop()
+                // play_next_skippable already stopped playback.
                 vec![PlaybackEvent::PlaybackStopped]
             }
         } else {
@@ -291,46 +300,42 @@ impl PlaybackState {
         })
     }
 
-    /// Go to the previous non-explicit track. If skip_explicit is enabled,
-    /// keeps going backwards until a non-explicit track is found or no more
-    /// tracks remain. Returns Some(id) if a track was found, None if playback
-    /// should seek to start (position > 2s) or if all previous tracks are
-    /// explicit (in which case playback is stopped).
-    fn play_prev_skipping_explicit(&mut self) -> Option<String> {
-        if !self.skip_explicit {
-            return self.play_prev();
-        }
-
-        // Delegate the "more than 2 seconds in, seek to start" check to
-        // play_prev itself on the first call. If it returns None, that means
-        // it seeked to start (or there is no previous track) rather than
-        // changing track, so leave playback untouched.
+    /// Go to the previous playable track, skipping any that must not be played.
+    /// Returns Some(id), or None if play_prev seeked to start or no playable
+    /// previous track remains (playback stopped).
+    fn play_prev_skippable(&mut self) -> Option<String> {
+        // play_prev handles the "more than 2s in, seek to start" case; None here
+        // means it seeked or there is no previous track, so leave playback alone.
         let first = self.play_prev()?;
-        if !self.current_song_is_explicit() {
+        if !self.current_song_should_skip() {
             return Some(first);
         }
-        debug!("Skipping explicit track '{}' (previous)", first);
+        debug!(
+            "Skipping track '{}' (previous, unplayable or explicit-filtered)",
+            first
+        );
 
-        // Continue skipping backwards. Force seek position to 0 before each
-        // call so play_prev doesn't trigger the "restart current track" path.
-        let max_skips = self.songs.len();
+        // Force position to 0 so play_prev doesn't restart the current track.
+        let max_skips = self.songs.len().max(self.songs.partial_len()).max(1);
         for _ in 1..max_skips {
             self.seek_position.set(0, true);
             let id = match self.play_prev() {
                 Some(id) => id,
                 None => {
-                    // Reached the beginning with only explicit tracks behind
-                    // us - stop playback.
+                    // Nothing playable behind us.
                     self.stop();
                     return None;
                 }
             };
-            if !self.current_song_is_explicit() {
+            if !self.current_song_should_skip() {
                 return Some(id);
             }
-            debug!("Skipping explicit track '{}' (previous)", id);
+            debug!(
+                "Skipping track '{}' (previous, unplayable or explicit-filtered)",
+                id
+            );
         }
-        // All previous tracks are explicit - stop playback
+        // Nothing playable left.
         self.stop();
         None
     }
@@ -528,7 +533,7 @@ impl UpdatableState for PlaybackState {
                     events.push(PlaybackEvent::SkipExplicitChanged(skip));
                 }
                 // If enabling while an explicit track is playing, skip it now.
-                events.extend(self.skip_current_if_explicit());
+                events.extend(self.skip_current_if_needed());
                 events
             }
             PlaybackAction::SetExplicitFilterLocked(locked) => {
@@ -542,7 +547,7 @@ impl UpdatableState for PlaybackState {
                 }
                 // If the filter just turned on while an explicit track is
                 // playing, skip it now.
-                events.extend(self.skip_current_if_explicit());
+                events.extend(self.skip_current_if_needed());
                 events
             }
             PlaybackAction::ToggleShuffle => {
@@ -550,7 +555,7 @@ impl UpdatableState for PlaybackState {
                 vec![PlaybackEvent::ShuffleChanged(self.is_shuffled)]
             }
             PlaybackAction::Next => {
-                if let Some(id) = self.play_next_skipping_explicit() {
+                if let Some(id) = self.play_next_skippable() {
                     vec![PlaybackEvent::TrackChanged(id)]
                 } else {
                     self.stop();
@@ -562,7 +567,7 @@ impl UpdatableState for PlaybackState {
                 vec![PlaybackEvent::PlaybackStopped]
             }
             PlaybackAction::Previous => {
-                if let Some(id) = self.play_prev_skipping_explicit() {
+                if let Some(id) = self.play_prev_skippable() {
                     vec![PlaybackEvent::TrackChanged(id)]
                 } else if self.list_position.is_some() {
                     // A track is still loaded, so play_prev seeked to its start
@@ -577,14 +582,13 @@ impl UpdatableState for PlaybackState {
             }
             PlaybackAction::Load(id) => {
                 if self.play(&id) {
-                    // If skip_explicit is enabled and the loaded track is explicit,
-                    // skip forward to the next non-explicit track instead.
-                    if self.skip_explicit && self.current_song_is_explicit() {
-                        debug!("Requested explicit track '{}', skipping", id);
-                        if let Some(next_id) = self.play_next_skipping_explicit() {
+                    // If the loaded track must be skipped, advance to the next playable one.
+                    if self.current_song_should_skip() {
+                        debug!("Requested track '{}' must be skipped (unplayable or explicit-filtered)", id);
+                        if let Some(next_id) = self.play_next_skippable() {
                             vec![PlaybackEvent::TrackChanged(next_id)]
                         } else {
-                            // play_next_skipping_explicit already called self.stop()
+                            // play_next_skippable already stopped playback.
                             vec![PlaybackEvent::PlaybackStopped]
                         }
                     } else {
@@ -731,6 +735,7 @@ mod tests {
             art: None,
             track_number: None,
             explicit: false,
+            playable: true,
         }
     }
 
@@ -1134,6 +1139,7 @@ mod tests {
             art: None,
             track_number: None,
             explicit: true,
+            playable: true,
         }
     }
 
@@ -1376,5 +1382,118 @@ mod tests {
         assert!(!events
             .iter()
             .any(|e| matches!(e, PlaybackEvent::TrackSeeked(_))));
+    }
+
+    fn unplayable_song(id: &str) -> SongDescription {
+        SongDescription {
+            id: id.to_string(),
+            uri: "".to_string(),
+            title: "Unplayable Title".to_string(),
+            artists: vec![],
+            album: AlbumRef {
+                id: "".to_string(),
+                name: "".to_string(),
+            },
+            duration_ms: 1000,
+            art: None,
+            track_number: None,
+            explicit: false,
+            playable: false,
+        }
+    }
+
+    #[test]
+    fn test_unplayable_track_skipped_on_next_without_filter() {
+        let mut state = PlaybackState::default();
+        // skip_explicit is off by default; unplayable tracks must still skip.
+        state.queue(vec![
+            song("1"),
+            unplayable_song("2"),
+            unplayable_song("3"),
+            song("4"),
+        ]);
+
+        state.play("1");
+        assert_eq!(state.current_song_id(), Some("1".to_string()));
+
+        let events = state.update_with(Cow::Owned(PlaybackAction::Next));
+        assert!(state.is_playing());
+        assert_eq!(state.current_song_id(), Some("4".to_string()));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::TrackChanged(id) if id == "4")));
+    }
+
+    #[test]
+    fn test_unplayable_track_skipped_on_load() {
+        let mut state = PlaybackState::default();
+        state.queue(vec![song("1"), unplayable_song("2"), song("3")]);
+
+        // Trying to load an unplayable track skips forward to "3".
+        let events = state.update_with(Cow::Owned(PlaybackAction::Load("2".to_string())));
+        assert!(state.is_playing());
+        assert_eq!(state.current_song_id(), Some("3".to_string()));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::TrackChanged(id) if id == "3")));
+    }
+
+    #[test]
+    fn test_unplayable_track_skipped_on_previous() {
+        let mut state = PlaybackState::default();
+        state.queue(vec![
+            song("1"),
+            unplayable_song("2"),
+            unplayable_song("3"),
+            song("4"),
+        ]);
+
+        state.play("4");
+        assert_eq!(state.current_song_id(), Some("4".to_string()));
+
+        let events = state.update_with(Cow::Owned(PlaybackAction::Previous));
+        assert!(state.is_playing());
+        assert_eq!(state.current_song_id(), Some("1".to_string()));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::TrackChanged(id) if id == "1")));
+    }
+
+    #[test]
+    fn test_all_unplayable_stops_playback() {
+        let mut state = PlaybackState::default();
+        state.queue(vec![song("1"), unplayable_song("2"), unplayable_song("3")]);
+
+        state.play("1");
+        assert!(state.is_playing());
+
+        // Next has only unplayable tracks left, so playback stops.
+        let events = state.update_with(Cow::Owned(PlaybackAction::Next));
+        assert!(!state.is_playing());
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::PlaybackStopped)));
+    }
+
+    #[test]
+    fn test_unplayable_skipped_together_with_explicit() {
+        let mut state = PlaybackState::default();
+        state.update_with(Cow::Owned(PlaybackAction::SetSkipExplicit(true)));
+        state.queue(vec![
+            song("1"),
+            unplayable_song("2"),
+            explicit_song("3"),
+            song("4"),
+        ]);
+
+        state.play("1");
+
+        // Next skips the unplayable "2" and the explicit "3", landing on "4".
+        let events = state.update_with(Cow::Owned(PlaybackAction::Next));
+        assert!(state.is_playing());
+        assert_eq!(state.current_song_id(), Some("4".to_string()));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, PlaybackEvent::TrackChanged(id) if id == "4")));
     }
 }

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -3,6 +3,8 @@ use librespot::core::SpotifyUri;
 use tokio::task;
 use url::Url;
 
+use gettextrs::gettext;
+
 use crate::app::state::{LoginAction, PlaybackAction};
 use crate::app::AppAction;
 use crate::auth::TokenStore;
@@ -53,6 +55,8 @@ pub enum Command {
     // genuinely unavailable); the event listener can't make that call because
     // it only holds a snapshot of the session that may have been replaced.
     TrackUnavailable,
+    // First successful playback since login; persist the account as known-good.
+    MarkPlaybackVerified,
     // Re-query the account's explicit content filter (e.g. after a track was
     // rejected with ExplicitContentFiltered) and sync Riff's filter state.
     RecheckExplicitFilter,
@@ -75,6 +79,13 @@ pub enum Command {
     // exercising the token-refresh flow on demand.
     #[cfg(debug_assertions)]
     DevExpireToken,
+    // Dev tools only: clear the verified marker and re-arm DRM detection.
+    #[cfg(debug_assertions)]
+    DevResetDrmVerification,
+    // Dev tools only: simulate one "track failed to load" event on a healthy
+    // session, feeding the failure counter.
+    #[cfg(debug_assertions)]
+    DevSimulateTrackUnavailable,
 }
 
 #[derive(Clone)]
@@ -93,6 +104,10 @@ impl AppPlayerDelegate {
 
     fn end_of_track_reached(&self) {
         self.send(PlaybackAction::Next.into())
+    }
+
+    fn stop_playback(&self) {
+        self.send(PlaybackAction::Stop.into())
     }
 
     fn token_login_successful(&self, username: String) {
@@ -116,6 +131,10 @@ impl AppPlayerDelegate {
             SpotifyError::NotPremium => LoginAction::SetNotPremium.into(),
             SpotifyError::LoginFailed => LoginAction::SetLoginFailure.into(),
             SpotifyError::LoggedOut => LoginAction::Logout.into(),
+            SpotifyError::PlaybackDrmBlocked => AppAction::ShowDrmBlockedDialog,
+            SpotifyError::PlaybackTemporarilyUnavailable => {
+                AppAction::ShowNotification(gettext("Playback is temporarily unavailable"))
+            }
             _ => AppAction::ShowNotification(format!("{error}")),
         })
     }

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -44,6 +44,12 @@ pub enum SpotifyError {
     LoggedOut,
     PlayerNotReady,
     TechnicalError,
+    // Every track fails to decrypt (librespot "audio key error"): the signature
+    // of Spotify's PlayPlay DRM, which blocks playback entirely.
+    PlaybackDrmBlocked,
+    // Many tracks failed to load in a row on an account that has already played
+    // this session, so likely transient rather than a DRM block.
+    PlaybackTemporarilyUnavailable,
 }
 
 impl Error for SpotifyError {}
@@ -58,9 +64,23 @@ impl fmt::Display for SpotifyError {
             Self::TechnicalError => {
                 write!(f, "A technical error occured. Check your connectivity.")
             }
+            Self::PlaybackDrmBlocked => write!(
+                f,
+                "Playback is not available for this account. Spotify's PlayPlay DRM \
+                 is proprietary and cannot be implemented outside the official client."
+            ),
+            Self::PlaybackTemporarilyUnavailable => {
+                write!(f, "Playback is temporarily unavailable.")
+            }
         }
     }
 }
+
+// Consecutive load failures before we stop playback, halting a runaway churn
+// through the queue. If nothing has played since login, this run also signals
+// PlayPlay DRM. High enough that one removed album won't trip it.
+// See https://github.com/librespot-org/librespot/issues/1649.
+const CONSECUTIVE_UNAVAILABLE_STOP_THRESHOLD: u32 = 10;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AudioBackend {
@@ -283,6 +303,15 @@ pub struct SpotifyPlayer {
     // while the connection is down. Once the session is rebuilt, the player
     // advances to the next track instead of sitting in silence.
     advance_after_reconnect: Arc<AtomicBool>,
+    // Consecutive load failures; see CONSECUTIVE_UNAVAILABLE_STOP_THRESHOLD.
+    // Reset when a track plays and when the threshold fires.
+    consecutive_load_failures: Arc<AtomicU32>,
+    // Whether any track has played since login. If so, load failures are
+    // individual unavailable tracks, not a DRM block. Reset on login/logout,
+    // not on reconnect.
+    has_played_since_login: Arc<AtomicBool>,
+    // Logged-in account id, used to persist the verified-playable marker.
+    current_user_id: Option<String>,
 
     // Cached "explicit filter locked" state for the account, so we avoid
     // re-querying the profile once we know the filter is locked for the
@@ -337,6 +366,9 @@ impl SpotifyPlayer {
             // Flags shared with the player event task.
             connection_lost: Arc::new(AtomicBool::new(false)),
             advance_after_reconnect: Arc::new(AtomicBool::new(false)),
+            consecutive_load_failures: Arc::new(AtomicU32::new(0)),
+            has_played_since_login: Arc::new(AtomicBool::new(false)),
+            current_user_id: None,
 
             explicit_filter_locked: false,
             delegate,
@@ -470,14 +502,24 @@ impl SpotifyPlayer {
                     self.track_needs_reload = true;
                     return self.try_background_reconnect().await;
                 }
-                warn!("Track unavailable, skipping");
-                // Gracefully skip the track that could not be played.
-                self.delegate.end_of_track_reached();
-                // The account explicit filter may have changed since login.
-                // Re-query it so Riff's filter state stays in sync.
-                let _ = self
-                    .command_sender
-                    .unbounded_send(Command::RecheckExplicitFilter);
+                self.handle_unavailable_track();
+                Ok(())
+            }
+            #[cfg(debug_assertions)]
+            Command::DevSimulateTrackUnavailable => {
+                // Run the real handler without the session health check.
+                warn!("[dev] Simulating an unavailable track failure");
+                self.handle_unavailable_track();
+                Ok(())
+            }
+            Command::MarkPlaybackVerified => {
+                // A track played, so this account is not DRM-blocked; persist it once.
+                if let Some(user_id) = self.current_user_id.as_deref() {
+                    if !user_id.is_empty() && crate::settings::drm_verified_user() != user_id {
+                        info!("Recording account as verified playable");
+                        crate::settings::set_drm_verified_user(user_id);
+                    }
+                }
                 Ok(())
             }
             Command::Logout => {
@@ -496,6 +538,8 @@ impl SpotifyPlayer {
                 self.next_reconnect_at = None;
                 self.connection_lost.store(false, Ordering::Relaxed);
                 self.advance_after_reconnect.store(false, Ordering::Relaxed);
+                self.consecutive_load_failures.store(0, Ordering::Relaxed);
+                self.has_played_since_login.store(false, Ordering::Relaxed);
                 self.delegate.set_connection_lost(false);
                 Ok(())
             }
@@ -679,6 +723,16 @@ impl SpotifyPlayer {
                     }
                 }
             }
+            #[cfg(debug_assertions)]
+            Command::DevResetDrmVerification => {
+                warn!("[dev] Clearing verified-playable marker and re-arming DRM detection");
+                // Forget the persisted known-good account.
+                crate::settings::clear_drm_verified_user();
+                // Re-arm detection for the current session.
+                self.has_played_since_login.store(false, Ordering::Relaxed);
+                self.consecutive_load_failures.store(0, Ordering::Relaxed);
+                Ok(())
+            }
         }
     }
 
@@ -686,6 +740,10 @@ impl SpotifyPlayer {
         &mut self,
         credentials: credentials::Credentials,
     ) -> Result<(), SpotifyError> {
+        // Fresh login: reset the failure run so a previous account can't trip
+        // a DRM block. has_played_since_login is seeded per-account below.
+        self.consecutive_load_failures.store(0, Ordering::Relaxed);
+
         // Check if the account is premium before connecting to librespot.
         // librespot will crash the process for free accounts, so we must
         // catch this early and report a graceful error instead.
@@ -700,6 +758,18 @@ impl SpotifyPlayer {
         if !profile.is_premium {
             warn!("Account is not premium, aborting login");
             return Err(SpotifyError::NotPremium);
+        }
+
+        // Seed DRM detection from the persisted per-account marker: a known-good
+        // account starts as "already played" so its unavailable tracks aren't
+        // mistaken for a DRM block.
+        let known_good =
+            !profile.user_id.is_empty() && crate::settings::drm_verified_user() == profile.user_id;
+        self.current_user_id = Some(profile.user_id.clone());
+        self.has_played_since_login
+            .store(known_good, Ordering::Relaxed);
+        if known_good {
+            debug!("Account previously verified as playable; DRM detection disabled");
         }
 
         // Sync the explicit content filter from the user's Spotify account.
@@ -829,6 +899,36 @@ impl SpotifyPlayer {
                 true
             }
         }
+    }
+
+    /// Handle a track that failed to load on a healthy session: count the
+    /// failure and, past the threshold, stop playback (DRM dialog if nothing
+    /// has played, otherwise a transient toast). Below it, skip the track.
+    fn handle_unavailable_track(&mut self) {
+        warn!("Track unavailable, skipping");
+        let failures = self
+            .consecutive_load_failures
+            .fetch_add(1, Ordering::Relaxed)
+            + 1;
+        if failures >= CONSECUTIVE_UNAVAILABLE_STOP_THRESHOLD {
+            warn!("{failures} tracks failed to load back-to-back; stopping playback");
+            // Nothing has ever played: signature of PlayPlay DRM. Otherwise transient.
+            if !self.has_played_since_login.load(Ordering::Relaxed) {
+                self.delegate.report_error(SpotifyError::PlaybackDrmBlocked);
+            } else {
+                self.delegate
+                    .report_error(SpotifyError::PlaybackTemporarilyUnavailable);
+            }
+            // Reset so the stop can fire again if failures continue.
+            self.consecutive_load_failures.store(0, Ordering::Relaxed);
+            self.delegate.stop_playback();
+            return;
+        }
+        self.delegate.end_of_track_reached();
+        // The account's explicit filter may have changed; re-query it.
+        let _ = self
+            .command_sender
+            .unbounded_send(Command::RecheckExplicitFilter);
     }
 
     /// Whether the librespot session or player died and must be recreated.
@@ -1024,6 +1124,8 @@ impl SpotifyPlayer {
             Arc::clone(&self.last_position_ms),
             Arc::clone(&self.connection_lost),
             Arc::clone(&self.advance_after_reconnect),
+            Arc::clone(&self.consecutive_load_failures),
+            Arc::clone(&self.has_played_since_login),
         ));
         self.player.replace(new_player);
     }
@@ -1231,6 +1333,8 @@ async fn player_setup_delegate(
     last_position_ms: Arc<AtomicU32>,
     connection_lost: Arc<AtomicBool>,
     advance_after_reconnect: Arc<AtomicBool>,
+    consecutive_load_failures: Arc<AtomicU32>,
+    has_played_since_login: Arc<AtomicBool>,
 ) {
     while let Some(event) = channel.recv().await {
         match event {
@@ -1260,6 +1364,12 @@ async fn player_setup_delegate(
                 // the delegate (and its UI) when the flag actually changes.
                 if connection_lost.swap(false, Ordering::Relaxed) {
                     delegate.set_connection_lost(false);
+                }
+                // A track played: not DRM-blocked. Clear the failure run and,
+                // on the first play this login, persist the account as known-good.
+                consecutive_load_failures.store(0, Ordering::Relaxed);
+                if !has_played_since_login.swap(true, Ordering::Relaxed) {
+                    let _ = command_sender.unbounded_send(Command::MarkPlaybackVerified);
                 }
                 last_position_ms.store(position_ms, Ordering::Relaxed);
                 delegate.notify_playback_state(position_ms);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,6 +13,24 @@ use librespot::playback::config::{AudioFormat, Bitrate, NormalisationMethod, Nor
 
 const SETTINGS: &str = "dev.diegovsky.Riff";
 
+/// Spotify user id recorded as verified-playable, or empty if none.
+pub fn drm_verified_user() -> String {
+    gio::Settings::new(SETTINGS)
+        .string("drm-verified-user")
+        .to_string()
+}
+
+/// Records `user_id` as verified-playable so it isn't reported as DRM-blocked later.
+pub fn set_drm_verified_user(user_id: &str) {
+    let _ = gio::Settings::new(SETTINGS).set_string("drm-verified-user", user_id);
+}
+
+/// Clears the verified-playable account so DRM detection runs again. Dev tools only.
+#[cfg(debug_assertions)]
+pub fn clear_drm_verified_user() {
+    let _ = gio::Settings::new(SETTINGS).set_string("drm-verified-user", "");
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum CloseWindowBehavior {
     #[default]


### PR DESCRIPTION
Added notice for account possibly affected by Spotify's PlayPlay DRM. 
Tracks which are region locked or filtered due to explicit  content now show up as greyed out with a tooltip explaining why.
Added dev tool to test new notice and consecutive track failures. 


Back to the mines I go...