### PR TITLE
Default to System's Accent Color

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,6 +1,3 @@
-@define-color accent_bg_color @green_5;
-@define-color accent_color @green_3;
-
 @keyframes skeleton-pulse {
   0% { opacity: 0.6; }
   50% { opacity: 1.0; }


### PR DESCRIPTION
For Mintu! We now default to the system's accent color. No clue why there was on override setting the color to green in the first place. 

<img width="893" height="1205" alt="Screenshot From 2026-07-30 23-01-43" src="https://github.com/user-attachments/assets/2b923ae8-b136-4fec-86d6-fcb1d778c682" />
<img width="893" height="593" alt="Screenshot From 2026-07-30 23-01-31" src="https://github.com/user-attachments/assets/994aca9d-4b8b-4001-acc3-76bde11b2360" />
