### PR TITLE
fix(dbus): emit MPRIS Seeked signal on seek

### DIFF
--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -59,7 +59,7 @@ async fn dbus_server(
                     }
                     MprisStateUpdate::SetPositionMs(position) => {
                         player.state_mut().set_position(position);
-                        Ok(())
+                        RiffMprisPlayer::seeked(ctxt, position as i64).await
                     }
                     MprisStateUpdate::SetLoopStatus {
                         has_prev,


### PR DESCRIPTION
This PR changes the D-Bus handler to emit a MPRIS Seeked signal on TrackSeeked/SeekSynced. External listeners (such as apps that display synced lyrics for the current track) may use this to react to position changes, as apps are expected to only re-query the current position if manually seeked.