### PR TITLE
fix(playback): center mobile bar controls when no track is selected

### DIFF
--- a/src/app/components/shell/playback/playback_info_mobile.blp
+++ b/src/app/components/shell/playback/playback_info_mobile.blp
@@ -1,14 +1,29 @@
 using Gtk 4.0;
 
+// Mirror the side-slot balance used by `now_playing_start` /
+// `playback_center` in playback_widget.blp: equal expanding flanks keep the
+// track label centred whether a song is selected or the empty-state text is
+// shown, and keep the strip aligned with the transport controls below.
 template $PlaybackInfoMobileWidget : Box {
+  orientation: horizontal;
   halign: fill;
   valign: center;
   hexpand: true;
 
+  Box {
+    hexpand: true;
+    width-request: 40;
+  }
+
   Label now_playing_label {
     halign: center;
-    hexpand: true;
+    hexpand: false;
     ellipsize: end;
     single-line-mode: true;
+  }
+
+  Box {
+    hexpand: true;
+    width-request: 40;
   }
 }

--- a/src/app/components/shell/playback/playback_info_mobile.rs
+++ b/src/app/components/shell/playback/playback_info_mobile.rs
@@ -44,12 +44,17 @@ impl PlaybackInfoMobileWidget {
             glib::markup_escape_text(title),
             glib::markup_escape_text(artist)
         );
-        self.imp().now_playing_label.set_markup(&markup);
+        let label = &self.imp().now_playing_label;
+        label.set_markup(&markup);
+        // Cap label width so a long title/artist cannot starve the side
+        // spacers and walk the bar off-centre (same role as ellipsis inside
+        // the desktop `now_playing_start` column).
+        label.set_max_width_chars(48);
     }
 
     pub fn reset_info(&self) {
-        self.imp()
-            .now_playing_label
-            .set_text(&gettext("No Track Playing"));
+        let label = &self.imp().now_playing_label;
+        label.set_text(&gettext("No Track Playing"));
+        label.set_max_width_chars(-1);
     }
 }

--- a/src/app/components/shell/playback/playback_widget.blp
+++ b/src/app/components/shell/playback/playback_widget.blp
@@ -64,36 +64,32 @@ template $PlaybackWidget : Box {
         volume_button.visible: true;
         playback_center.margin-start: 16;
         playback_center.margin-end: 16;
-        // Narrow: drop equal thirds. The transport controls need more than a
-        // third on a phone-width window, so let each slot take its natural
-        // size; the expanding side slots keep the controls centred.
-        playback_center.homogeneous: false;
       }
     }
 
-    // Desktop: three equal-width columns (now playing, controls, volume). The
-    // homogeneous split means the now-playing card is bounded by its own column
-    // and can never grow into the controls' column, so the centred controls
-    // stay put no matter how long the title or artist is. The narrow breakpoint
-    // turns homogeneity off (see above).
-    child: Box playback_center {
-      orientation: horizontal;
-      homogeneous: true;
+    // CenterBox keeps the transport controls geometrically centred for both
+    // wide and narrow windows, including when no track is selected (empty
+    // start slot vs volume button on the end). A plain homogeneous Box only
+    // balances leftover expand space after natural widths, so an empty start
+    // and a visible volume control offsets the play button to the left.
+    child: CenterBox playback_center {
       halign: fill;
       hexpand: true;
+      shrink-center-last: true;
       height-request: 68;
       margin-top: 8;
       margin-bottom: 8;
       margin-start: 8;
       margin-end: 8;
 
-      // The side slots expand so that, when homogeneity is off in narrow mode,
-      // they absorb the leftover width equally and keep the controls centred.
-      // Under homogeneity (desktop) the expand is a no-op; every column is equal.
+      // Matching min width on both side slots so an empty start (no track)
+      // still balances the end volume control in narrow mode.
+      [start]
       Box now_playing_start {
         hexpand: true;
         halign: start;
         valign: center;
+        width-request: 40;
 
         // Narrow mode replaces the track info with a compact button. The
         // breakpoint toggles this box; the button inside is shown in code only
@@ -122,8 +118,8 @@ template $PlaybackWidget : Box {
           overflow: hidden;
           halign: start;
 
-          // The card is bounded by its equal-width column, so a long title or
-          // artist ellipsizes within the column instead of widening it.
+          // Ellipsize long titles inside the start slot so they cannot push
+          // the centred controls or the volume control off-window.
           $PlaybackInfoWidget now_playing {
             receives-default: "1";
             halign: "start";
@@ -134,19 +130,22 @@ template $PlaybackWidget : Box {
         }
       }
 
+      [center]
       $PlaybackControlsWidget controls {
-        // Keep the control cluster at its natural width, centred in its column.
+        // Keep the control cluster at natural width. Its template sets
+        // hexpand:true, but with CenterBox shrink-center-last an expanding
+        // centre squeezes the start/end slots and pushes the volume off-edge.
         hexpand: false;
         halign: center;
         valign: center;
       }
 
-      // Right column. Expands only to help centre the controls when homogeneity
-      // is off (narrow mode); its content is aligned to the right edge.
+      [end]
       Box {
         hexpand: true;
         halign: end;
         valign: center;
+        width-request: 40;
 
         Box volume_slider_box {
           width-request: 250;


### PR DESCRIPTION
## Summary
Fixes playback bar alignment on narrow/mobile widths so the play button stays centered when no track is selected.

## Changes
- Restore `CenterBox` for the playback row (`playback_widget.blp`) so transport controls are geometrically centered even when the start slot is empty and only the volume control is present on the end.
- Give both side slots a matching `width-request` so an empty start still balances the end control.
- Mirror the same side-slot balance on `playback_info_mobile` (equal expanding flanks around the label) and cap long title width so the strip cannot walk off-centre.

## Test plan
- [ ] Narrow window, no track: play button is centered
- [ ] Narrow window, track selected: play button stays centered; now-playing button and volume visible
- [ ] Wide window, with/without track: controls remain centered
- [ ] Resize wide ↔ narrow: no overflow, seamless transition

Fixes #194