### PR TITLE
Made Audio cache size configurable

### DIFF
--- a/crates/riff-api/src/cache/texture.rs
+++ b/crates/riff-api/src/cache/texture.rs
@@ -22,6 +22,10 @@ impl TextureCache {
     pub fn insert(&self, key: String, texture: gdk::Texture, byte_size: usize) {
         self.inner.lock().unwrap().insert(key, texture, byte_size);
     }
+
+    pub fn clear(&self) {
+        self.inner.lock().unwrap().clear();
+    }
 }
 
 #[cfg(test)]

--- a/crates/riff-api/src/service.rs
+++ b/crates/riff-api/src/service.rs
@@ -65,11 +65,13 @@ impl ApiService {
         self.image_disk.evict_to_budget().await;
     }
 
-    /// Clear all user-specific cached data (memory + API disk). The image
-    /// cache is content-addressed and safe to keep.
+    /// Clear all cached data, on disk (API responses + images) and in memory
+    /// (API response cache + decoded textures).
     pub async fn clear_user_cache(&self) {
         self.json_cache.clear();
+        self.texture_cache.clear();
         self.api_disk.clear().await;
+        self.image_disk.clear().await;
     }
 
     fn handle_auth_error(&self, err: &DomainError) {

--- a/data/dev.diegovsky.Riff.gschema.xml
+++ b/data/dev.diegovsky.Riff.gschema.xml
@@ -290,5 +290,11 @@
       <summary>Maximum disk space (MB) for the on-disk data cache</summary>
       <description>Upper bound on disk space used to cache API responses.</description>
     </key>
+    <key name="audio-cache-size-mb" type="u">
+      <range min="64" max="16384"/>
+      <default>1024</default>
+      <summary>Maximum disk space (MB) for the on-disk audio cache</summary>
+      <description>Upper bound on disk space used to cache downloaded audio data.</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/app/components/pages/settings/settings.blp
+++ b/src/app/components/pages/settings/settings.blp
@@ -325,6 +325,23 @@ template $SettingsWindow : Adw.PreferencesDialog {
         };
       }
 
+      Adw.SpinRow audio_cache_size {
+        /* Translators: Title for the disk audio cache size preference */
+
+        title: _("Audio Cache Size (MB)");
+
+        /* Translators: Description for the disk audio cache size preference */
+
+        subtitle: _("Maximum disk space allocated for caching downloaded audio.");
+        adjustment: Adjustment {
+          lower: 64;
+          upper: 16384;
+          value: 1024;
+          step-increment: 64;
+          page-increment: 256;
+        };
+      }
+
       Adw.ActionRow {
         /* Translators: Title for the clear cache action row */
 

--- a/src/app/components/pages/settings/settings.rs
+++ b/src/app/components/pages/settings/settings.rs
@@ -107,6 +107,9 @@ mod imp {
         pub disk_cache_size: TemplateChild<libadwaita::SpinRow>,
 
         #[template_child]
+        pub audio_cache_size: TemplateChild<libadwaita::SpinRow>,
+
+        #[template_child]
         pub clear_cache_button: TemplateChild<gtk::Button>,
     }
 
@@ -649,6 +652,20 @@ impl SettingsDialog {
             let settings = settings.clone();
             disk_adjustment.connect_value_changed(move |adj| {
                 let _ = settings.set_uint("disk-cache-size-mb", adj.value() as u32);
+            });
+        }
+
+        // Audio cache on disk size (MB).
+        let audio_cache_size = widget
+            .audio_cache_size
+            .downcast_ref::<libadwaita::SpinRow>()
+            .unwrap();
+        let audio_adjustment = audio_cache_size.adjustment();
+        audio_adjustment.set_value(settings.uint("audio-cache-size-mb") as f64);
+        {
+            let settings = settings.clone();
+            audio_adjustment.connect_value_changed(move |adj| {
+                let _ = settings.set_uint("audio-cache-size-mb", adj.value() as u32);
             });
         }
     }

--- a/src/app/components/pages/settings/settings_model.rs
+++ b/src/app/components/pages/settings/settings_model.rs
@@ -26,11 +26,13 @@ impl SettingsModel {
             .dispatch(SettingsAction::ChangeSettings.into());
     }
 
-    /// Clear the on-disk and in-memory data caches, then notify the user.
+    /// Clear the on-disk and in-memory data caches, plus librespot's
+    /// downloaded audio cache, then notify the user.
     pub fn clear_cache(&self) {
         let api = self.app_model.api();
         self.dispatcher.dispatch_async(Box::pin(async move {
             api.clear_user_cache().await;
+            crate::player::clear_audio_cache();
             // Translators: Toast shown after the user clears the cache in settings.
             Some(AppAction::ShowNotification(gettext("Cache cleared")))
         }));

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -1144,13 +1144,22 @@ fn librespot_cache_root() -> std::path::PathBuf {
     glib::user_cache_dir().join("riff").join("librespot")
 }
 
+pub fn clear_audio_cache() {
+    let audio_dir = librespot_cache_root().join("audio");
+    if let Err(e) = std::fs::remove_dir_all(&audio_dir) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            warn!("Failed to clear librespot audio cache: {e}");
+        }
+    }
+}
+
 fn open_librespot_cache() -> Option<Cache> {
     let root = librespot_cache_root();
     Cache::new(
         Some(root.join("credentials")),
         Some(root.join("volume")),
         Some(root.join("audio")),
-        None,
+        Some(crate::settings::audio_cache_size_limit_bytes()),
     )
     .map_err(|e| dbg!(e))
     .ok()

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -31,6 +31,12 @@ pub fn clear_drm_verified_user() {
     let _ = gio::Settings::new(SETTINGS).set_string("drm-verified-user", "");
 }
 
+/// User-configured limit for librespot's on-disk audio cache, in bytes.
+pub fn audio_cache_size_limit_bytes() -> u64 {
+    let mb = gio::Settings::new(SETTINGS).uint("audio-cache-size-mb") as u64;
+    mb * 1024 * 1024
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum CloseWindowBehavior {
     #[default]


### PR DESCRIPTION
## Problem
There has been a long standing bug where the librespot audio cache had an unbounded size. I have personally seen the audio cache reach 7GB. 

## Solution
This PR adds a default cache size to prevent run away librespot audio caches. Furthmore, the user can configure how large or small they want the cache on their machine via the setting page.

## Related  Ticket
https://github.com/Diegovsky/riff/issues/47