### PR TITLE
Hide main window during sign in, removed redundant code

### DIFF
--- a/src/app/components/shell/window/mod.rs
+++ b/src/app/components/shell/window/mod.rs
@@ -5,10 +5,11 @@ use gettextrs::gettext;
 use gio::prelude::SettingsExt;
 use gtk::prelude::*;
 use libadwaita::prelude::*;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use crate::app::components::EventListener;
+use crate::app::state::LoginEvent;
 use crate::app::{AppEvent, AppModel};
 use crate::settings::{CloseWindowBehavior, WindowGeometry};
 
@@ -23,6 +24,7 @@ thread_local! {
 pub struct MainWindow {
     initial_window_geometry: WindowGeometry,
     window: libadwaita::ApplicationWindow,
+    logged_in: Cell<bool>,
 }
 
 impl MainWindow {
@@ -73,6 +75,7 @@ impl MainWindow {
         Self {
             initial_window_geometry,
             window,
+            logged_in: Cell::new(false),
         }
     }
 
@@ -158,11 +161,22 @@ impl MainWindow {
         if self.initial_window_geometry.is_maximized {
             self.window.maximize();
         }
-        self.window.present();
     }
 
     fn raise(&self) {
+        if self.logged_in.get() {
+            self.window.present();
+        }
+    }
+
+    fn show(&self) {
+        self.logged_in.set(true);
         self.window.present();
+    }
+
+    fn hide(&self) {
+        self.logged_in.set(false);
+        self.window.set_visible(false);
     }
 
     fn save_window_geometry<W: GtkWindowExt>(window: &W) {
@@ -185,6 +199,10 @@ impl EventListener for MainWindow {
             AppEvent::Started => self.start(),
             AppEvent::Raised => self.raise(),
             AppEvent::DrmBlockedDialogShown => self.show_drm_blocked_dialog(),
+            AppEvent::LoginEvent(LoginEvent::LoginCompleted) => self.show(),
+            AppEvent::LoginEvent(LoginEvent::LoginShown | LoginEvent::LogoutCompleted) => {
+                self.hide()
+            }
             _ => {}
         }
     }

--- a/src/app/components/widgets/card_list/component.rs
+++ b/src/app/components/widgets/card_list/component.rs
@@ -144,10 +144,6 @@ impl<M: CardListPageModel + 'static> EventListener for CardListComponent<M> {
                 self.card_list.show_placeholders();
                 self.model.refresh();
             }
-            AppEvent::LoginEvent(LoginEvent::LogoutCompleted) => {
-                self.card_list.widget().remove_all();
-                self.page_widget.status_page().set_visible(false);
-            }
             AppEvent::BrowserEvent(
                 BrowserEvent::CardLayoutChanged(_) | BrowserEvent::CardSizeChanged(_),
             ) => {

--- a/src/app/state/app_state.rs
+++ b/src/app/state/app_state.rs
@@ -291,23 +291,6 @@ impl AppState {
             AppAction::PlaybackAction(a) => forward_action(a, &mut self.playback),
             AppAction::BrowserAction(a) => forward_action(a, &mut self.browser),
             AppAction::SelectionAction(a) => forward_action(a, &mut self.selection),
-            AppAction::LoginAction(LoginAction::Logout) => {
-                let mut events = forward_action(LoginAction::Logout, &mut self.logged_user);
-                if let Some(home) = self.browser.home_state_mut() {
-                    home.albums.replace_all(std::iter::empty());
-                    home.playlists.replace_all(std::iter::empty());
-                    home.saved_tracks.clear().commit();
-                }
-                events.extend(forward_action(
-                    BrowserAction::NavigationPopTo(ScreenName::Home),
-                    &mut self.browser,
-                ));
-                self.playback = Default::default();
-                events.push(BrowserEvent::LibraryUpdated.into());
-                events.push(BrowserEvent::SavedPlaylistsUpdated.into());
-                events.push(BrowserEvent::SavedTracksUpdated.into());
-                events
-            }
             AppAction::LoginAction(a) => forward_action(a, &mut self.logged_user),
             AppAction::SettingsAction(a) => forward_action(a, &mut self.settings),
             _ => vec![],


### PR DESCRIPTION
## Summary
Improved sign in experience by hiding the main window. Now the user only sees the sign in dialog after logging out or sign in for the first time. This brings Riff inline with other apps in gnome circle.

## Related Ticket: 
https://github.com/xou816/spot/issues/641